### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/example/runner_pool.dart
+++ b/example/runner_pool.dart
@@ -4,8 +4,6 @@
 
 library isolate.example.runner_pool;
 
-import 'dart:async' show Future;
-
 import 'package:isolate/load_balancer.dart';
 import 'package:isolate/isolate_runner.dart';
 

--- a/lib/load_balancer.dart
+++ b/lib/load_balancer.dart
@@ -5,7 +5,7 @@
 /// A load-balancing runner pool.
 library isolate.load_balancer;
 
-import 'dart:async' show Future, FutureOr;
+import 'dart:async' show FutureOr;
 
 import 'runner.dart';
 import 'src/errors.dart';

--- a/lib/registry.dart
+++ b/lib/registry.dart
@@ -5,7 +5,7 @@
 /// An isolate-compatible object registry and lookup service.
 library isolate.registry;
 
-import 'dart:async' show Future, Completer, TimeoutException;
+import 'dart:async' show Completer, TimeoutException;
 import 'dart:collection' show HashMap, HashSet;
 import 'dart:isolate' show RawReceivePort, SendPort, Capability;
 

--- a/lib/runner.dart
+++ b/lib/runner.dart
@@ -6,7 +6,7 @@
 /// or even isolate.
 library isolate.runner;
 
-import 'dart:async' show Future, FutureOr;
+import 'dart:async' show FutureOr;
 
 /// Calls a function with an argument.
 ///

--- a/test/isolaterunner_test.dart
+++ b/test/isolaterunner_test.dart
@@ -4,7 +4,6 @@
 
 library isolate.test.isolaterunner_test;
 
-import 'dart:async' show Future;
 import 'dart:isolate' show Capability;
 
 import 'package:isolate/isolate_runner.dart';


### PR DESCRIPTION
As of Dart 2.1, Future/Stream have been exported from dart:core.