### PR TITLE
Migrate to null-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0-dev
+
+* Migrate to null-safety
+
 ## 2.0.3
 
 * Update SDK requirements.

--- a/example/http_server.dart
+++ b/example/http_server.dart
@@ -12,7 +12,7 @@ import 'package:isolate/isolate_runner.dart';
 import 'package:isolate/ports.dart';
 import 'package:isolate/runner.dart';
 
-Future<Future<Object> Function()> runHttpServer(
+Future<Future<Object?> Function()> runHttpServer(
     Runner runner, int port, HttpListener listener) async {
   var stopPort = await runner.run(_startHttpServer, [port, listener]);
 
@@ -53,7 +53,7 @@ class EchoHttpListener implements HttpListener {
   static final _id = Isolate.current.hashCode;
   final SendPort _counter;
 
-  StreamSubscription _subscription;
+  StreamSubscription? _subscription;
 
   EchoHttpListener(this._counter);
 
@@ -77,7 +77,7 @@ class EchoHttpListener implements HttpListener {
   @override
   Future stop() async {
     print('Stopping isolate $_id');
-    await _subscription.cancel();
+    await _subscription?.cancel();
     _subscription = null;
   }
 }
@@ -97,12 +97,13 @@ void main(List<String> args) async {
       await ServerSocket.bind(InternetAddress.anyIPv6, port, shared: true);
 
   port = socket.port;
-  var isolates = await Future.wait(
+  var isolates = await Future.wait<IsolateRunner>(
       Iterable.generate(5, (_) => IsolateRunner.spawn()), cleanUp: (isolate) {
     isolate.close();
   });
 
-  var stoppers = await Future.wait(isolates.map((IsolateRunner isolate) {
+  var stoppers = await Future.wait<Future<Object?> Function()>(
+      isolates.map((IsolateRunner isolate) {
     return runHttpServer(isolate, socket.port, listener);
   }), cleanUp: (shutdownServer) {
     shutdownServer();

--- a/example/runner_pool.dart
+++ b/example/runner_pool.dart
@@ -32,19 +32,19 @@ void main() {
 Future<List<int>> parfib(int limit, int parallelity) {
   return LoadBalancer.create(parallelity, IsolateRunner.spawn)
       .then((LoadBalancer pool) {
-    var fibs = List<Future<int>>.filled(limit + 1, null);
+    var fibs = <Future<int>>[];
     // Schedule all calls with exact load value and the heaviest task
     // assigned first.
     void schedule(a, b, i) {
       if (i < limit) {
         schedule(a + b, a, i + 1);
       }
-      fibs[i] = pool.run<int, int>(fib, i, load: a);
+      fibs.add(pool.run<int, int>(fib, i, load: a));
     }
 
     schedule(0, 1, 0);
     // And wait for them all to complete.
-    return Future.wait(fibs).whenComplete(pool.close);
+    return Future.wait(fibs.reversed).whenComplete(pool.close);
   });
 }
 

--- a/lib/registry.dart
+++ b/lib/registry.dart
@@ -69,7 +69,7 @@ const int _findValue = 5;
 ///   var aWords = await dictionaryByFirstLetter.lookup(tags: [task.letter]);
 ///   ...
 /// }
-/// ```register
+/// ```
 ///
 /// A registry can be treated like a distributed multimap from tags to
 /// objects, if each tag is only used once. Example:

--- a/lib/runner.dart
+++ b/lib/runner.dart
@@ -36,7 +36,7 @@ class Runner {
   ///
   /// The default implementation runs the function in the current isolate.
   Future<R> run<R, P>(FutureOr<R> Function(P argument) function, P argument,
-      {Duration timeout, FutureOr<R> Function() onTimeout}) {
+      {Duration? timeout, FutureOr<R> Function()? onTimeout}) {
     var result = Future.sync(() => function(argument));
     if (timeout != null) {
       result = result.timeout(timeout, onTimeout: onTimeout);

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -40,16 +40,16 @@ class MultiError extends Error {
   ///
   /// The order of values is not preserved (if that is needed, use
   /// [wait]).
-  static Future<List<Object>> waitUnordered<T>(Iterable<Future<T>> futures,
-      {void Function(T successResult) cleanUp}) {
-    Completer<List<Object>> completer;
+  static Future<List<Object?>> waitUnordered<T>(Iterable<Future<T>> futures,
+      {void Function(T successResult)? cleanUp}) {
+    late Completer<List<Object?>> completer;
     var count = 0;
     var errors = 0;
     var values = 0;
     // Initialized to `new List(count)` when count is known.
     // Filled up with values on the left, errors on the right.
     // Order is not preserved.
-    List<Object> results;
+    late List<Object?> results;
     void checkDone() {
       if (errors + values < count) return;
       if (errors == 0) {
@@ -74,7 +74,7 @@ class MultiError extends Error {
       if (errors == 0 && cleanUp != null) {
         for (var i = 0; i < values; i++) {
           var value = results[i];
-          if (value != null) Future.sync(() => cleanUp(value));
+          if (value != null) Future.sync(() => cleanUp(value as T));
         }
       }
       results[results.length - ++errors] = e;
@@ -99,16 +99,16 @@ class MultiError extends Error {
   /// The order of values is preserved, and if any error occurs, the
   /// [MultiError.errors] list will have errors in the corresponding slots,
   /// and `null` for non-errors.
-  Future<List<Object>> wait<T>(Iterable<Future<T>> futures,
-      {void Function(T successResult) cleanUp}) {
-    Completer<List<Object>> completer;
+  Future<List<Object?>> wait<T>(Iterable<Future<T>> futures,
+      {void Function(T successResult)? cleanUp}) {
+    late Completer<List<Object?>> completer;
     var count = 0;
     var hasError = false;
     var completed = 0;
     // Initialized to `new List(count)` when count is known.
     // Filled with values until the first error, then cleared
     // and filled with errors.
-    List<Object> results;
+    late List<Object?> results;
     void checkDone() {
       completed++;
       if (completed < count) return;
@@ -134,10 +134,10 @@ class MultiError extends Error {
           if (cleanUp != null) {
             for (var i = 0; i < results.length; i++) {
               var result = results[i];
-              if (result != null) Future.sync(() => cleanUp(result));
+              if (result != null) Future.sync(() => cleanUp(result as T));
             }
           }
-          results = List<Object>.filled(count, null);
+          results = List<Object?>.filled(count, null);
           hasError = true;
         }
         results[i] = e;
@@ -145,7 +145,7 @@ class MultiError extends Error {
       });
     }
     if (count == 0) return Future.value(List.filled(0, null));
-    results = List<T>.filled(count, null);
+    results = List<T?>.filled(count, null);
     completer = Completer();
     return completer.future;
   }

--- a/lib/src/raw_receive_port_multiplexer.dart
+++ b/lib/src/raw_receive_port_multiplexer.dart
@@ -31,12 +31,12 @@ import 'util.dart';
 class _MultiplexRawReceivePort implements RawReceivePort {
   final RawReceivePortMultiplexer _multiplexer;
   final int _id;
-  Function _handler;
+  Function? _handler;
 
   _MultiplexRawReceivePort(this._multiplexer, this._id, this._handler);
 
   @override
-  set handler(Function handler) {
+  set handler(Function? handler) {
     _handler = handler;
   }
 
@@ -49,7 +49,7 @@ class _MultiplexRawReceivePort implements RawReceivePort {
   SendPort get sendPort => _multiplexer._createSendPort(_id);
 
   void _invokeHandler(message) {
-    _handler(message);
+    _handler?.call(message);
   }
 }
 
@@ -75,7 +75,7 @@ class RawReceivePortMultiplexer {
     _port.handler = _multiplexResponse;
   }
 
-  RawReceivePort createRawReceivePort([void Function(dynamic) handler]) {
+  RawReceivePort createRawReceivePort([void Function(dynamic)? handler]) {
     var id = _nextId++;
     var result = _MultiplexRawReceivePort(this, id, handler);
     _map[id] = result;

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -10,21 +10,21 @@
 void ignore(_) {}
 
 /// Create a single-element fixed-length list.
-List<Object> list1(Object v1) => List.filled(1, v1);
+List<Object?> list1(Object? v1) => List.filled(1, v1);
 
 /// Create a two-element fixed-length list.
-List<Object> list2(Object v1, Object v2) => List.filled(2, null)
+List<Object?> list2(Object? v1, Object? v2) => List.filled(2, null)
   ..[0] = v1
   ..[1] = v2;
 
 /// Create a three-element fixed-length list.
-List<Object> list3(Object v1, Object v2, Object v3) => List.filled(3, null)
+List<Object?> list3(Object? v1, Object? v2, Object? v3) => List.filled(3, null)
   ..[0] = v1
   ..[1] = v2
   ..[2] = v3;
 
 /// Create a four-element fixed-length list.
-List<Object> list4(Object v1, Object v2, Object v3, Object v4) =>
+List<Object?> list4(Object? v1, Object? v2, Object? v3, Object? v4) =>
     List.filled(4, null)
       ..[0] = v1
       ..[1] = v2
@@ -32,7 +32,8 @@ List<Object> list4(Object v1, Object v2, Object v3, Object v4) =>
       ..[3] = v4;
 
 /// Create a five-element fixed-length list.
-List<Object> list5(Object v1, Object v2, Object v3, Object v4, Object v5) =>
+List<Object?> list5(
+        Object? v1, Object? v2, Object? v3, Object? v4, Object? v5) =>
     List.filled(5, null)
       ..[0] = v1
       ..[1] = v2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,12 @@
 name: isolate
-version: 2.0.3
-author: Dart Team <misc@dartlang.org>
+version: 3.0.0-dev
 description: >-
   Utility functions and classes related to the 'dart:isolate' library.
 homepage: https://github.com/dart-lang/isolate
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
-  pedantic: ^1.0.0
-  test: ^1.0.0
+  pedantic: ^1.10.0
+  test: ^1.16.0

--- a/test/ports_test.dart
+++ b/test/ports_test.dart
@@ -118,11 +118,7 @@ void testSingleCompletePort() {
       throw 89;
     });
     p.send(42);
-    return completer.future.then((v) {
-      fail('unreachable');
-    }, onError: (e, s) {
-      expect(e, 89);
-    });
+    return expectLater(completer.future, throwsA(89));
   });
 
   test('ValueCallbackThrowsFuture', () {
@@ -132,11 +128,7 @@ void testSingleCompletePort() {
       return Future.error(90);
     });
     p.send(42);
-    return completer.future.then((v) {
-      fail('unreachable');
-    }, onError: (e, s) {
-      expect(e, 90);
-    });
+    return expectLater(completer.future, throwsA(90));
   });
 
   test('FirstValue', () {
@@ -174,11 +166,7 @@ void testSingleCompletePort() {
   test('Timeout', () {
     var completer = Completer.sync();
     singleCompletePort(completer, timeout: _ms * 100);
-    return completer.future.then((v) {
-      fail('unreachable');
-    }, onError: (e, s) {
-      expect(e is TimeoutException, isTrue);
-    });
+    return expectLater(completer.future, throwsA(isA<TimeoutException>()));
   });
 
   test('TimeoutCallback', () {
@@ -193,11 +181,7 @@ void testSingleCompletePort() {
     var completer = Completer.sync();
     singleCompletePort(completer,
         timeout: _ms * 100, onTimeout: () => throw 91);
-    return completer.future.then((v) {
-      fail('unreachable');
-    }, onError: (e, s) {
-      expect(e, 91);
-    });
+    return expectLater(completer.future, throwsA(91));
   });
 
   test('TimeoutCallbackFuture', () {
@@ -213,14 +197,10 @@ void testSingleCompletePort() {
     var completer = Completer.sync();
     singleCompletePort(completer,
         timeout: _ms * 100, onTimeout: () => Future.error(92));
-    return completer.future.then((v) {
-      fail('unreachable');
-    }, onError: (e, s) {
-      expect(e, 92);
-    });
+    return expectLater(completer.future, throwsA(92));
   });
 
-  test('TimeoutCallbackSLow', () {
+  test('TimeoutCallbackSlow', () {
     var completer = Completer.sync();
     singleCompletePort(completer,
         timeout: _ms * 100,
@@ -235,11 +215,7 @@ void testSingleCompletePort() {
     singleCompletePort(completer,
         timeout: _ms * 100,
         onTimeout: () => Future.delayed(_ms * 500, () => throw 87));
-    return completer.future.then((v) {
-      fail('unreachable');
-    }, onError: (e, s) {
-      expect(e, 87);
-    });
+    return expectLater(completer.future, throwsA(87));
   });
 
   test('TimeoutFirst', () {
@@ -247,9 +223,7 @@ void testSingleCompletePort() {
     var p =
         singleCompletePort(completer, timeout: _ms * 100, onTimeout: () => 37);
     Timer(_ms * 500, () => p.send(42));
-    return completer.future.then((v) {
-      expect(v, 37);
-    });
+    return expectLater(completer.future, completion(37));
   });
 }
 
@@ -272,13 +246,9 @@ void testSingleResponseFuture() {
   });
 
   test('FutureError', () {
-    return singleResponseFuture((SendPort p) {
+    return expectLater(singleResponseFuture((SendPort p) {
       throw 93;
-    }).then((v) {
-      fail('unreachable');
-    }, onError: (e, s) {
-      expect(e, 93);
-    });
+    }), throwsA(93));
   });
 
   test('FutureTimeout', () {
@@ -319,45 +289,31 @@ void testSingleResultFuture() {
   });
 
   test('Error', () {
-    return singleResultFuture((SendPort p) {
+    return expectLater(singleResultFuture((SendPort p) {
       sendFutureResult(Future.error(94), p);
-    }).then((v) {
-      fail('unreachable');
-    }, onError: (e, s) {
-      expect(e is RemoteError, isTrue);
-    });
+    }), throwsA(isA<RemoteError>()));
   });
 
   test('ErrorFirst', () {
-    return singleResultFuture((SendPort p) {
+    return expectLater(singleResultFuture((SendPort p) {
       sendFutureResult(Future.error(95), p);
       sendFutureResult(Future.error(96), p);
-    }).then((v) {
-      fail('unreachable');
-    }, onError: (e, s) {
-      expect(e is RemoteError, isTrue);
-    });
+    }), throwsA(isA<RemoteError>()));
   });
 
   test('Error', () {
-    return singleResultFuture((SendPort p) {
+    return expectLater(singleResultFuture((SendPort p) {
       throw 93;
-    }).then((v) {
-      fail('unreachable');
-    }, onError: (e, s) {
-      expect(e is RemoteError, isTrue);
-    });
+    }), throwsA(isA<RemoteError>()));
   });
 
   test('Timeout', () {
-    return singleResultFuture((SendPort p) {
-      // no-op.
-    }, timeout: _ms * 100)
-        .then((v) {
-      fail('unreachable');
-    }, onError: (e, s) {
-      expect(e is TimeoutException, isTrue);
-    });
+    return expectLater(
+      singleResultFuture((SendPort p) {
+        // no-op.
+      }, timeout: _ms * 100),
+      throwsA(isA<TimeoutException>()),
+    );
   });
 
   test('TimeoutValue', () {
@@ -398,7 +354,7 @@ void testSingleResponseChannel() {
   });
 
   test('ValueCallback', () {
-    var channel = SingleResponseChannel(callback: (v) => 2 * v);
+    var channel = SingleResponseChannel(callback: (num v) => 2 * v);
     channel.port.send(42);
     return channel.result.then((v) {
       expect(v, 84);
@@ -408,15 +364,12 @@ void testSingleResponseChannel() {
   test('ErrorCallback', () {
     var channel = SingleResponseChannel(callback: (v) => throw 42);
     channel.port.send(37);
-    return channel.result.then((v) {
-      fail('unreachable');
-    }, onError: (v, s) {
-      expect(v, 42);
-    });
+    return expectLater(channel.result, throwsA(42));
   });
 
   test('AsyncValueCallback', () {
-    var channel = SingleResponseChannel(callback: (v) => Future.value(2 * v));
+    var channel =
+        SingleResponseChannel(callback: (num v) => Future.value(2 * v));
     channel.port.send(42);
     return channel.result.then((v) {
       expect(v, 84);
@@ -426,11 +379,8 @@ void testSingleResponseChannel() {
   test('AsyncErrorCallback', () {
     var channel = SingleResponseChannel(callback: (v) => Future.error(42));
     channel.port.send(37);
-    return channel.result.then((v) {
-      fail('unreachable');
-    }, onError: (v, s) {
-      expect(v, 42);
-    });
+
+    return expectLater(channel.result, throwsA(42));
   });
 
   test('Timeout', () {
@@ -443,11 +393,7 @@ void testSingleResponseChannel() {
   test('TimeoutThrow', () {
     var channel =
         SingleResponseChannel(timeout: _ms * 100, throwOnTimeout: true);
-    return channel.result.then((v) {
-      fail('unreachable');
-    }, onError: (v, s) {
-      expect(v is TimeoutException, isTrue);
-    });
+    return expectLater(channel.result, throwsA(isA<TimeoutException>()));
   });
 
   test('TimeoutThrowOnTimeoutAndValue', () {
@@ -456,11 +402,7 @@ void testSingleResponseChannel() {
         throwOnTimeout: true,
         onTimeout: () => 42,
         timeoutValue: 42);
-    return channel.result.then((v) {
-      fail('unreachable');
-    }, onError: (v, s) {
-      expect(v is TimeoutException, isTrue);
-    });
+    return expectLater(channel.result, throwsA(isA<TimeoutException>()));
   });
 
   test('TimeoutOnTimeout', () {
@@ -489,28 +431,19 @@ void testSingleResponseChannel() {
   test('TimeoutOnTimeoutError', () {
     var channel =
         SingleResponseChannel(timeout: _ms * 100, onTimeout: () => throw 42);
-    return channel.result.then((v) {
-      fail('unreachable');
-    }, onError: (v, s) {
-      expect(v, 42);
-    });
+
+    return expectLater(channel.result, throwsA(42));
   });
 
   test('TimeoutOnTimeoutAsync', () {
     var channel = SingleResponseChannel(
         timeout: _ms * 100, onTimeout: () => Future.value(42));
-    return channel.result.then((v) {
-      expect(v, 42);
-    });
+    return expectLater(channel.result, completion(42));
   });
 
   test('TimeoutOnTimeoutAsyncError', () {
     var channel = SingleResponseChannel(
         timeout: _ms * 100, onTimeout: () => Future.error(42));
-    return channel.result.then((v) {
-      fail('unreachable');
-    }, onError: (v, s) {
-      expect(v, 42);
-    });
+    return expectLater(channel.result, throwsA(42));
   });
 }


### PR DESCRIPTION
Migrates this package to null-safety.

There are some things I wasn't sure about:

- `List.filled` is used in a bunch of places, probably for performance reasons. I replaced most of that with growing lists, in one place I introduced a sentinel value instead. I'm not sure what the best approach is here
- I had to rewrite some tests to use `expectLater(future , throwsA())` instead of using `future.onError(...)`. I was getting weird errors with `Null is not a subtype of Future<Never>` otherwise. Those errors only happened in tests (running the same code outside of a test works fine). I couldn't figure out why that happens after hours of debugging so I gave up. I think those errors might be coming from the `dart:async` implementation or a weird zone introduced by tests. The type error happens when calling `completer.completeError` so I don't think this library is causing them.

Closes #43 