### PR TITLE
enable null-safety

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,7 @@
 include: package:pedantic/analysis_options.yaml
-#analyzer:
-#  strong-mode:
-#    implicit-casts: false
+analyzer:
+  strong-mode:
+    implicit-casts: false
 linter:
   rules:
     - avoid_empty_else

--- a/example/http_server.dart
+++ b/example/http_server.dart
@@ -16,7 +16,7 @@ Future<Future<Object?> Function()> runHttpServer(
     Runner runner, int port, HttpListener listener) async {
   var stopPort = await runner.run(_startHttpServer, [port, listener]);
 
-  return (() => _sendStop(stopPort!));
+  return (() => _sendStop(stopPort));
 }
 
 Future<Object?> _sendStop(SendPort stopPort) => singleResponseFuture(stopPort.send);

--- a/example/http_server.dart
+++ b/example/http_server.dart
@@ -22,8 +22,8 @@ Future<Future<Object?> Function()> runHttpServer(
 Future<Object?> _sendStop(SendPort stopPort) => singleResponseFutureWithoutTimeout(stopPort.send);
 
 Future<SendPort> _startHttpServer(List args) async {
-  int port = args[0];
-  HttpListener listener = args[1];
+  final port = args[0] as int;
+  final listener = args[1] as HttpListener;
 
   var server =
       await HttpServer.bind(InternetAddress.anyIPv6, port, shared: true);

--- a/example/http_server.dart
+++ b/example/http_server.dart
@@ -16,7 +16,7 @@ Future<Future<Object?> Function()> runHttpServer(
     Runner runner, int port, HttpListener listener) async {
   var stopPort = await runner.run(_startHttpServer, [port, listener]);
 
-  return (() => _sendStop(stopPort));
+  return () => _sendStop(stopPort);
 }
 
 Future<Object?> _sendStop(SendPort stopPort) => singleResponseFutureWithoutTimeout(stopPort.send);

--- a/example/http_server.dart
+++ b/example/http_server.dart
@@ -30,7 +30,7 @@ Future<SendPort> _startHttpServer(List args) async {
   await listener.start(server);
 
   return singleCallbackPort((SendPort? resultPort) {
-    sendFutureResult(Future.sync(listener.stop), resultPort);
+    sendFutureResult(Future.sync(listener.stop), resultPort!);
   });
 }
 

--- a/example/http_server.dart
+++ b/example/http_server.dart
@@ -19,7 +19,7 @@ Future<Future<Object?> Function()> runHttpServer(
   return (() => _sendStop(stopPort));
 }
 
-Future<Object?> _sendStop(SendPort stopPort) => singleResponseFuture(stopPort.send);
+Future<Object?> _sendStop(SendPort stopPort) => singleResponseFutureWithoutTimeout(stopPort.send);
 
 Future<SendPort> _startHttpServer(List args) async {
   int port = args[0];
@@ -29,8 +29,8 @@ Future<SendPort> _startHttpServer(List args) async {
       await HttpServer.bind(InternetAddress.anyIPv6, port, shared: true);
   await listener.start(server);
 
-  return singleCallbackPort((SendPort? resultPort) {
-    sendFutureResult(Future.sync(listener.stop), resultPort!);
+  return singleCallbackPortWithoutTimeout((SendPort resultPort) {
+    sendFutureResult(Future.sync(listener.stop), resultPort);
   });
 }
 

--- a/example/http_server.dart
+++ b/example/http_server.dart
@@ -19,7 +19,8 @@ Future<Future<Object?> Function()> runHttpServer(
   return () => _sendStop(stopPort);
 }
 
-Future<Object?> _sendStop(SendPort stopPort) => singleResponseFutureWithoutTimeout(stopPort.send);
+Future<Object?> _sendStop(SendPort stopPort) =>
+    singleResponseFutureWithoutTimeout(stopPort.send);
 
 Future<SendPort> _startHttpServer(List args) async {
   final port = args[0] as int;
@@ -97,15 +98,15 @@ void main(List<String> args) async {
       await ServerSocket.bind(InternetAddress.anyIPv6, port, shared: true);
 
   port = socket.port;
-  var isolates =
-      await Future.wait(Iterable.generate(5, (_) => IsolateRunner.spawn()),
-          cleanUp: (dynamic isolate) {
+  var isolates = await Future.wait<IsolateRunner>(
+      Iterable.generate(5, (_) => IsolateRunner.spawn()), cleanUp: (isolate) {
     isolate.close();
   });
 
-  var stoppers = await Future.wait(isolates.map((IsolateRunner isolate) {
+  var stoppers =
+      await Future.wait<Function>(isolates.map((IsolateRunner isolate) {
     return runHttpServer(isolate, socket.port, listener);
-  }), cleanUp: (dynamic shutdownServer) {
+  }), cleanUp: (shutdownServer) {
     shutdownServer();
   });
 

--- a/example/runner_pool.dart
+++ b/example/runner_pool.dart
@@ -35,7 +35,7 @@ Future<List<int>> parfib(int limit, int parallelity) {
     var fibs = List<Future<int>?>.filled(limit + 1, null);
     // Schedule all calls with exact load value and the heaviest task
     // assigned first.
-    void schedule(a, b, i) {
+    void schedule(int a, int b, int i) {
       if (i < limit) {
         schedule(a + b, a, i + 1);
       }

--- a/example/runner_pool.dart
+++ b/example/runner_pool.dart
@@ -6,8 +6,8 @@ library isolate.example.runner_pool;
 
 import 'dart:async' show Future;
 
-import 'package:isolate/load_balancer.dart';
 import 'package:isolate/isolate_runner.dart';
+import 'package:isolate/load_balancer.dart';
 
 void main() {
   var N = 44;
@@ -32,19 +32,19 @@ void main() {
 Future<List<int>> parfib(int limit, int parallelity) {
   return LoadBalancer.create(parallelity, IsolateRunner.spawn)
       .then((LoadBalancer pool) {
-    var fibs = List<Future<int>>.filled(limit + 1, null);
+    var fibs = List<Future<int>?>.filled(limit + 1, null);
     // Schedule all calls with exact load value and the heaviest task
     // assigned first.
     void schedule(a, b, i) {
       if (i < limit) {
         schedule(a + b, a, i + 1);
       }
-      fibs[i] = pool.run<int, int>(fib, i, load: a);
+      fibs[i] = pool.run<int, int>(fib, i, load: a).then((value) => value!);
     }
 
     schedule(0, 1, 0);
     // And wait for them all to complete.
-    return Future.wait(fibs).whenComplete(pool.close);
+    return Future.wait(fibs.cast<Future<int>>()).whenComplete(pool.close);
   });
 }
 

--- a/example/runner_pool.dart
+++ b/example/runner_pool.dart
@@ -39,7 +39,7 @@ Future<List<int>> parfib(int limit, int parallelity) {
       if (i < limit) {
         schedule(a + b, a, i + 1);
       }
-      fibs[i] = pool.run<int, int>(fib, i, load: a).then((value) => value);
+      fibs[i] = pool.run<int, int>(fib, i, load: a);
     }
 
     schedule(0, 1, 0);

--- a/example/runner_pool.dart
+++ b/example/runner_pool.dart
@@ -39,7 +39,7 @@ Future<List<int>> parfib(int limit, int parallelity) {
       if (i < limit) {
         schedule(a + b, a, i + 1);
       }
-      fibs[i] = pool.run<int, int>(fib, i, load: a).then((value) => value!);
+      fibs[i] = pool.run<int, int>(fib, i, load: a).then((value) => value);
     }
 
     schedule(0, 1, 0);

--- a/lib/isolate_runner.dart
+++ b/lib/isolate_runner.dart
@@ -101,7 +101,7 @@ class IsolateRunner implements Runner {
   ///  .timeout(new Duration(...), onTimeout: () => print("No response"));
   /// ```
   Future<void> kill({Duration timeout = const Duration(seconds: 1)}) {
-    var onExit = singleResponseFuture(isolate.addOnExitListener);
+    final onExit = singleResponseFutureWithoutTimeout(isolate.addOnExitListener);
     if (Duration.zero == timeout) {
       isolate.kill(priority: Isolate.immediate);
       return onExit;

--- a/lib/isolate_runner.dart
+++ b/lib/isolate_runner.dart
@@ -295,7 +295,7 @@ class IsolateRunnerRemote {
         var function = command[1] as Function;
         var argument = command[2];
         var responsePort = command[3] as SendPort;
-        sendFutureResult(Future.sync((() => function(argument))), responsePort);
+        sendFutureResult(Future.sync(() => function(argument)), responsePort);
         break;
     }
   }

--- a/lib/isolate_runner.dart
+++ b/lib/isolate_runner.dart
@@ -164,7 +164,11 @@ class IsolateRunner implements Runner {
   /// `resumeCapability`, a single resume call with stop the pause.
   void resume([Capability? resumeCapability]) {
     resumeCapability ??= isolate.pauseCapability;
-    isolate.resume(resumeCapability!);
+
+    /// according to [Isolate.resume] docs
+    /// calling with this capability won't have any effect
+    resumeCapability ??= Capability();
+    isolate.resume(resumeCapability);
   }
 
   /// Execute `function(argument)` in the isolate and return the result.

--- a/lib/isolate_runner.dart
+++ b/lib/isolate_runner.dart
@@ -203,11 +203,11 @@ class IsolateRunner implements Runner {
   /// The stream closes when the isolate shuts down.
   Stream get errors {
     late StreamController controller;
-    RawReceivePort? port;
+    late RawReceivePort port;
     void handleError(message) {
       if (message == null) {
         // Isolate shutdown.
-        port!.close();
+        port.close();
         controller.close();
       } else {
         // Uncaught error.
@@ -222,14 +222,13 @@ class IsolateRunner implements Runner {
         sync: true,
         onListen: () {
           port = RawReceivePort(handleError);
-          isolate.addErrorListener(port!.sendPort);
-          isolate.addOnExitListener(port!.sendPort);
+          isolate.addErrorListener(port.sendPort);
+          isolate.addOnExitListener(port.sendPort);
         },
         onCancel: () {
-          isolate.removeErrorListener(port!.sendPort);
-          isolate.removeOnExitListener(port!.sendPort);
-          port!.close();
-          port = null;
+          isolate.removeErrorListener(port.sendPort);
+          isolate.removeOnExitListener(port.sendPort);
+          port.close();
         });
     return controller.stream;
   }

--- a/lib/isolate_runner.dart
+++ b/lib/isolate_runner.dart
@@ -61,8 +61,8 @@ class IsolateRunner implements Runner {
     isolate.setErrorsFatal(false);
     var pingChannel = SingleResponseChannel();
     isolate.ping(pingChannel.port);
-    var commandPort = await channel.result;
-    var result = IsolateRunner(isolate, commandPort);
+    final commandPort = await channel.result as SendPort;
+    final result = IsolateRunner(isolate, commandPort);
     // Guarantees that setErrorsFatal has completed.
     await pingChannel.result;
     return result;
@@ -216,8 +216,8 @@ class IsolateRunner implements Runner {
         controller.close();
       } else {
         // Uncaught error.
-        String errorDescription = message[0];
-        String stackDescription = message[1];
+        final errorDescription = message[0] as String;
+        final stackDescription = message[1] as String;
         var error = RemoteError(errorDescription, stackDescription);
         controller.addError(error, error.stackTrace);
       }

--- a/lib/isolate_runner.dart
+++ b/lib/isolate_runner.dart
@@ -101,7 +101,8 @@ class IsolateRunner implements Runner {
   ///  .timeout(new Duration(...), onTimeout: () => print("No response"));
   /// ```
   Future<void> kill({Duration timeout = const Duration(seconds: 1)}) {
-    final onExit = singleResponseFutureWithoutTimeout(isolate.addOnExitListener);
+    final onExit =
+        singleResponseFutureWithoutTimeout(isolate.addOnExitListener);
     if (Duration.zero == timeout) {
       isolate.kill(priority: Isolate.immediate);
       return onExit;

--- a/lib/load_balancer.dart
+++ b/lib/load_balancer.dart
@@ -7,6 +7,8 @@ library isolate.load_balancer;
 
 import 'dart:async' show Future, FutureOr;
 
+import 'package:collection/collection.dart';
+
 import 'runner.dart';
 import 'src/errors.dart';
 import 'src/util.dart';
@@ -18,27 +20,18 @@ import 'src/util.dart';
 class LoadBalancer implements Runner {
   // A heap-based priority queue of entries, prioritized by `load`.
   // Each entry has its own entry in the queue, for faster update.
-  List<_LoadBalancerEntry> _queue;
-
-  // The number of entries currently in the queue.
-  int _length;
+  PriorityQueue<_LoadBalancerEntry> _queue;
 
   // Whether [stop] has been called.
-  Future<void> _stopFuture;
+  Future<void>? _stopFuture;
 
   /// Create a load balancer backed by the [Runner]s of [runners].
   LoadBalancer(Iterable<Runner> runners) : this._(_createEntries(runners));
 
-  LoadBalancer._(List<_LoadBalancerEntry> entries)
-      : _queue = entries,
-        _length = entries.length {
-    for (var i = 0; i < _length; i++) {
-      _queue[i].queueIndex = i;
-    }
-  }
+  LoadBalancer._(PriorityQueue<_LoadBalancerEntry> entries) : _queue = entries;
 
   /// The number of runners currently in the pool.
-  int get length => _length;
+  int get length => _queue.length;
 
   /// Asynchronously create [size] runners and create a `LoadBalancer` of those.
   ///
@@ -55,10 +48,10 @@ class LoadBalancer implements Runner {
     }).then((runners) => LoadBalancer(runners));
   }
 
-  static List<_LoadBalancerEntry> _createEntries(Iterable<Runner> runners) {
-    var entries = runners.map((runner) => _LoadBalancerEntry(runner));
-    return List<_LoadBalancerEntry>.from(entries, growable: false);
-  }
+  static PriorityQueue<_LoadBalancerEntry> _createEntries(
+          Iterable<Runner> runners) =>
+      PriorityQueue<_LoadBalancerEntry>()
+        ..addAll(runners.map((runner) => _LoadBalancerEntry(runner)));
 
   /// Execute the command in the currently least loaded isolate.
   ///
@@ -73,11 +66,12 @@ class LoadBalancer implements Runner {
   /// as normal. If the runners are running in other isolates, then
   /// the [onTimeout] function must be a constant function.
   @override
-  Future<R> run<R, P>(FutureOr<R> Function(P argument) function, argument,
-      {Duration timeout, FutureOr<R> Function() onTimeout, int load = 100}) {
+  Future<R?> run<R, P>(FutureOr<R> Function(P argument) function, P argument,
+      {Duration? timeout, FutureOr<R> Function()? onTimeout, int load = 100}) {
     RangeError.checkNotNegative(load, 'load');
-    var entry = _first;
-    _increaseLoad(entry, load);
+    final entry = _queue.removeFirst();
+    entry.load += 1;
+    _queue.add(entry);
     return entry.run(this, load, function, argument, timeout, onTimeout);
   }
 
@@ -95,26 +89,25 @@ class LoadBalancer implements Runner {
   /// If [timeout] and [onTimeout] are provided, they are forwarded to
   /// the runners running the function, which will handle any timeouts
   /// as normal.
-  List<Future<R>> runMultiple<R, P>(
+  List<FutureOr<R?>> runMultiple<R, P>(
       int count, FutureOr<R> Function(P argument) function, P argument,
-      {Duration timeout, FutureOr<R> Function() onTimeout, int load = 100}) {
-    RangeError.checkValueInInterval(count, 1, _length, 'count');
+      {Duration? timeout, FutureOr<R> Function()? onTimeout, int load = 100}) {
+    RangeError.checkValueInInterval(count, 1, length, 'count');
     RangeError.checkNotNegative(load, 'load');
     if (count == 1) {
-      return List<Future<R>>.filled(
+      return List<FutureOr<R?>>.filled(
           1,
           run(function, argument,
               load: load, timeout: timeout, onTimeout: onTimeout));
     }
-    var result = List<Future<R>>.filled(count, null);
-    if (count == _length) {
+    final result = List<FutureOr<R?>>.filled(count, null);
+    if (count == length) {
       // No need to change the order of entries in the queue.
-      for (var i = 0; i < count; i++) {
-        var entry = _queue[i];
+      _queue.unorderedElements.mapIndexed((index, entry) {
         entry.load += load;
-        result[i] =
+        result[index] =
             entry.run(this, load, function, argument, timeout, onTimeout);
-      }
+      }).forEach(ignore);
     } else {
       // Remove the [count] least loaded services and run the
       // command on each, then add them back to the queue.
@@ -122,14 +115,14 @@ class LoadBalancer implements Runner {
       // isolate.
       // We can't assume that the first [count] entries in the
       // heap list are the least loaded.
-      var entries = List<_LoadBalancerEntry>.filled(count, null);
+      var entries = List<_LoadBalancerEntry?>.filled(count, null);
       for (var i = 0; i < count; i++) {
-        entries[i] = _removeFirst();
+        entries[i] = _queue.removeFirst();
       }
       for (var i = 0; i < count; i++) {
-        var entry = entries[i];
+        var entry = entries[i]!;
         entry.load += load;
-        _add(entry);
+        _queue.add(entry);
         result[i] =
             entry.run(this, load, function, argument, timeout, onTimeout);
       }
@@ -138,161 +131,41 @@ class LoadBalancer implements Runner {
   }
 
   @override
-  Future<void> close() {
+  Future<void>? close() {
     if (_stopFuture != null) return _stopFuture;
     _stopFuture =
-        MultiError.waitUnordered(_queue.take(_length).map((e) => e.close()))
+        MultiError.waitUnordered(_queue.removeAll().map((e) => e.close()))
             .then(ignore);
-    // Remove all entries.
-    for (var i = 0; i < _length; i++) {
-      _queue[i].queueIndex = -1;
-    }
-    _queue = null;
-    _length = 0;
     return _stopFuture;
-  }
-
-  /// Place [element] in heap at [index] or above.
-  ///
-  /// Put element into the empty cell at `index`.
-  /// While the `element` has higher priority than the
-  /// parent, swap it with the parent.
-  void _bubbleUp(_LoadBalancerEntry element, int index) {
-    while (index > 0) {
-      var parentIndex = (index - 1) ~/ 2;
-      var parent = _queue[parentIndex];
-      if (element.compareTo(parent) > 0) break;
-      _queue[index] = parent;
-      parent.queueIndex = index;
-      index = parentIndex;
-    }
-    _queue[index] = element;
-    element.queueIndex = index;
-  }
-
-  /// Place [element] in heap at [index] or above.
-  ///
-  /// Put element into the empty cell at `index`.
-  /// While the `element` has lower priority than either child,
-  /// swap it with the highest priority child.
-  void _bubbleDown(_LoadBalancerEntry element, int index) {
-    while (true) {
-      var childIndex = index * 2 + 1; // Left child index.
-      if (childIndex >= _length) break;
-      var child = _queue[childIndex];
-      var rightChildIndex = childIndex + 1;
-      if (rightChildIndex < _length) {
-        var rightChild = _queue[rightChildIndex];
-        if (rightChild.compareTo(child) < 0) {
-          childIndex = rightChildIndex;
-          child = rightChild;
-        }
-      }
-      if (element.compareTo(child) <= 0) break;
-      _queue[index] = child;
-      child.queueIndex = index;
-      index = childIndex;
-    }
-    _queue[index] = element;
-    element.queueIndex = index;
-  }
-
-  /// Removes the entry from the queue, but doesn't stop its service.
-  ///
-  /// The entry is expected to be either added back to the queue
-  /// immediately or have its stop method called.
-  void _remove(_LoadBalancerEntry entry) {
-    var index = entry.queueIndex;
-    if (index < 0) return;
-    entry.queueIndex = -1;
-    _length--;
-    var replacement = _queue[_length];
-    _queue[_length] = null;
-    if (index < _length) {
-      if (entry.compareTo(replacement) < 0) {
-        _bubbleDown(replacement, index);
-      } else {
-        _bubbleUp(replacement, index);
-      }
-    }
-  }
-
-  /// Adds entry to the queue.
-  void _add(_LoadBalancerEntry entry) {
-    if (_stopFuture != null) throw StateError('LoadBalancer is stopped');
-    assert(entry.queueIndex < 0);
-    if (_queue.length == _length) {
-      _grow();
-    }
-    var index = _length;
-    _length = index + 1;
-    _bubbleUp(entry, index);
-  }
-
-  void _increaseLoad(_LoadBalancerEntry entry, int load) {
-    assert(load >= 0);
-    entry.load += load;
-    if (entry.inQueue) {
-      _bubbleDown(entry, entry.queueIndex);
-    }
-  }
-
-  void _decreaseLoad(_LoadBalancerEntry entry, int load) {
-    assert(load >= 0);
-    entry.load -= load;
-    if (entry.inQueue) {
-      _bubbleUp(entry, entry.queueIndex);
-    }
-  }
-
-  void _grow() {
-    var newQueue = List<_LoadBalancerEntry>.filled(_length * 2, null);
-    newQueue.setRange(0, _length, _queue);
-    _queue = newQueue;
-  }
-
-  _LoadBalancerEntry get _first {
-    assert(_length > 0);
-    return _queue[0];
-  }
-
-  _LoadBalancerEntry _removeFirst() {
-    var result = _first;
-    _remove(result);
-    return result;
   }
 }
 
 class _LoadBalancerEntry implements Comparable<_LoadBalancerEntry> {
   // The current load on the isolate.
   int load = 0;
-  // The current index in the heap-queue.
-  // Negative when the entry is not part of the queue.
-  int queueIndex = -1;
 
   // The service used to send commands to the other isolate.
   Runner runner;
 
   _LoadBalancerEntry(Runner runner) : runner = runner;
 
-  /// Whether the entry is still in the queue.
-  bool get inQueue => queueIndex >= 0;
-
-  Future<R> run<R, P>(
+  Future<R?> run<R, P>(
       LoadBalancer balancer,
       int load,
       FutureOr<R> Function(P argument) function,
-      argument,
-      Duration timeout,
-      FutureOr<R> Function() onTimeout) {
+      P argument,
+      Duration? timeout,
+      FutureOr<R> Function()? onTimeout) {
     return runner
         .run<R, P>(function, argument, timeout: timeout, onTimeout: onTimeout)
         .whenComplete(() {
-      balancer._decreaseLoad(this, load);
+      balancer._queue.remove(this);
+      load -= 1;
+      balancer._queue.add(this);
     });
   }
 
-  Future close() => runner.close();
+  Future? close() => runner.close();
 
   @override
   int compareTo(_LoadBalancerEntry other) => load - other.load;

--- a/lib/load_balancer.dart
+++ b/lib/load_balancer.dart
@@ -134,11 +134,12 @@ class LoadBalancer implements Runner {
 
   @override
   Future<void> close() {
-    if (_stopFuture != null) return _stopFuture!;
-    _stopFuture =
+    var stopFuture = _stopFuture;
+    if (stopFuture != null) return stopFuture;
+    _stopFuture = (stopFuture =
         MultiError.waitUnordered(_queue.removeAll().map((e) => e.close()))
-            .then(ignore);
-    return _stopFuture!;
+            .then(ignore));
+    return stopFuture;
   }
 }
 

--- a/lib/load_balancer.dart
+++ b/lib/load_balancer.dart
@@ -168,7 +168,7 @@ class _LoadBalancerEntry implements Comparable<_LoadBalancerEntry> {
     });
   }
 
-  Future? close() => runner.close();
+  Future close() => runner.close();
 
   @override
   int compareTo(_LoadBalancerEntry other) => load - other.load;

--- a/lib/ports.dart
+++ b/lib/ports.dart
@@ -46,12 +46,23 @@ import 'src/util.dart';
 ///       ..first.timeout(duration, () => timeoutValue).then(callback))
 ///     .sendPort
 /// ```
-SendPort singleCallbackPort<P>(void Function(P response) callback,
-    {Duration timeout, P timeoutValue}) {
+SendPort singleCallbackPort<P>(void Function(P? response) callback,
+        {Duration? timeout, P? timeoutValue}) =>
+    singleCallbackPortWithTimeout(
+      callback,
+      timeoutValue: timeoutValue,
+      timeout: timeout,
+    );
+
+SendPort singleCallbackPortWithTimeout<P>(
+  void Function(P response) callback, {
+  required P timeoutValue,
+  Duration? timeout,
+}) {
   var responsePort = RawReceivePort();
   var zone = Zone.current;
   callback = zone.registerUnaryCallback(callback);
-  Timer timer;
+  Timer? timer;
   responsePort.handler = (response) {
     responsePort.close();
     timer?.cancel();
@@ -93,21 +104,21 @@ SendPort singleCallbackPort<P>(void Function(P response) callback,
 ///
 /// Returns the `SendPort` expecting the single message.
 SendPort singleCompletePort<R, P>(Completer<R> completer,
-    {FutureOr<R> Function(P message) callback,
-    Duration timeout,
-    FutureOr<R> Function() onTimeout}) {
+    {FutureOr<R>? Function(P message)? callback,
+    Duration? timeout,
+    FutureOr<R> Function()? onTimeout}) {
   if (callback == null && timeout == null) {
     return singleCallbackPort<Object>((response) {
-      _castComplete<R>(completer, response);
+      _castComplete<R?>(completer, response);
     });
   }
   var responsePort = RawReceivePort();
-  Timer timer;
+  Timer? timer;
   if (callback == null) {
     responsePort.handler = (response) {
       responsePort.close();
       timer?.cancel();
-      _castComplete<R>(completer, response);
+      _castComplete<R?>(completer, response);
     };
   } else {
     var zone = Zone.current;
@@ -159,13 +170,29 @@ SendPort singleCompletePort<R, P>(Completer<R> completer,
 /// If you want a timeout on the returned future, it's recommended to
 /// use the [timeout] parameter, and not [Future.timeout] on the result.
 /// The `Future` method won't be able to close the underlying [ReceivePort].
-Future<R> singleResponseFuture<R>(void Function(SendPort responsePort) action,
-    {Duration timeout, R timeoutValue}) {
+Future<R?> singleResponseFuture<R>(
+  void Function(SendPort responsePort) action, {
+  Duration? timeout,
+  R? timeoutValue,
+}) =>
+    singleResponseFutureWithTimeout(
+      action,
+      timeout: timeout,
+      timeoutValue: timeoutValue,
+    );
+
+/// Same as [singleResponseFuture], but with required timeoutValue,
+/// this allows us to return non-nullable value
+Future<R> singleResponseFutureWithTimeout<R>(
+  void Function(SendPort responsePort) action, {
+  Duration? timeout,
+  required R timeoutValue,
+}) {
   var completer = Completer<R>.sync();
   var responsePort = RawReceivePort();
-  Timer timer;
+  Timer? timer;
   var zone = Zone.current;
-  responsePort.handler = (Object response) {
+  responsePort.handler = (response) {
     responsePort.close();
     timer?.cancel();
     zone.run(() {
@@ -196,11 +223,11 @@ Future<R> singleResponseFuture<R>(void Function(SendPort responsePort) action,
 /// The result of [future] is sent on [resultPort] in a form expected by
 /// either [receiveFutureResult], [completeFutureResult], or
 /// by the port of [singleResultFuture].
-void sendFutureResult(Future<Object> future, SendPort resultPort) {
-  future.then((value) {
-    resultPort.send(list1(value));
+void sendFutureResult(Future<Object?> future, SendPort? resultPort) {
+  future.then<Null>((value) {
+    resultPort!.send(list1(value));
   }, onError: (error, stack) {
-    resultPort.send(list2('$error', '$stack'));
+    resultPort!.send(list2('$error', '$stack'));
   });
 }
 
@@ -223,9 +250,9 @@ void sendFutureResult(Future<Object> future, SendPort resultPort) {
 /// If `onTimeout` is omitted, it defaults to throwing
 /// a [TimeoutException].
 Future<R> singleResultFuture<R>(void Function(SendPort responsePort) action,
-    {Duration timeout, FutureOr<R> Function() onTimeout}) {
+    {Duration? timeout, FutureOr<R> Function()? onTimeout}) {
   var completer = Completer<R>.sync();
-  var port = singleCompletePort<R, List<Object>>(completer,
+  var port = singleCompletePort<R, List<Object?>>(completer,
       callback: receiveFutureResult, timeout: timeout, onTimeout: onTimeout);
   try {
     action(port);
@@ -239,12 +266,12 @@ Future<R> singleResultFuture<R>(void Function(SendPort responsePort) action,
 /// Completes a completer with a message created by [sendFutureResult]
 ///
 /// The [response] must be a message on the format sent by [sendFutureResult].
-void completeFutureResult<R>(List<Object> response, Completer<R> completer) {
+void completeFutureResult<R>(List<Object?> response, Completer<R> completer) {
   if (response.length == 2) {
-    var error = RemoteError(response[0], response[1]);
+    var error = RemoteError(response[0] as String, response[1] as String);
     completer.completeError(error, error.stackTrace);
   } else {
-    R result = response[0];
+    final result = response[0] as R;
     completer.complete(result);
   }
 }
@@ -253,12 +280,12 @@ void completeFutureResult<R>(List<Object> response, Completer<R> completer) {
 /// result.
 ///
 /// The [response] must be a message on the format sent by [sendFutureResult].
-Future<R> receiveFutureResult<R>(List<Object> response) {
+Future<R> receiveFutureResult<R>(List<Object?> response) {
   if (response.length == 2) {
-    var error = RemoteError(response[0], response[1]);
+    var error = RemoteError(response[0] as String, response[1] as String);
     return Future.error(error, error.stackTrace);
   }
-  R result = response[0];
+  final result = response[0] as R;
   return Future<R>.value(result);
 }
 
@@ -269,9 +296,9 @@ Future<R> receiveFutureResult<R>(List<Object> response) {
 class SingleResponseChannel<R> {
   final Zone _zone;
   final RawReceivePort _receivePort;
-  final Completer<R> _completer;
-  final Function _callback;
-  Timer _timer;
+  final Completer<R?> _completer;
+  final Function? _callback;
+  Timer? _timer;
 
   /// Creates a response channel.
   ///
@@ -289,13 +316,13 @@ class SingleResponseChannel<R> {
   /// If `onTimeout` is not provided either,
   /// the future is completed with `timeoutValue`, which defaults to `null`.
   SingleResponseChannel(
-      {FutureOr<R> Function(Null value) callback,
-      Duration timeout,
+      {FutureOr<R> Function(Null value)? callback,
+      Duration? timeout,
       bool throwOnTimeout = false,
-      FutureOr<R> Function() onTimeout,
-      R timeoutValue})
+      FutureOr<R> Function()? onTimeout,
+      R? timeoutValue})
       : _receivePort = RawReceivePort(),
-        _completer = Completer<R>.sync(),
+        _completer = Completer<R?>.sync(),
         _callback = callback,
         _zone = Zone.current {
     _receivePort.handler = _handleResponse;
@@ -321,14 +348,15 @@ class SingleResponseChannel<R> {
   SendPort get port => _receivePort.sendPort;
 
   /// Future completed by the first value sent to [port].
-  Future<R> get result => _completer.future;
+  /// Null is only possible with null timeoutValue and
+  Future<R?> get result => _completer.future;
 
   /// If the channel hasn't completed yet, interrupt it and complete the result.
   ///
   /// If the channel hasn't received a value yet, or timed out, it is stopped
   /// (like by a timeout) and the [SingleResponseChannel.result]
   /// is completed with [result].
-  void interrupt([R result]) {
+  void interrupt([R? result]) {
     _receivePort.close();
     _cancelTimer();
     if (!_completer.isCompleted) {
@@ -339,7 +367,7 @@ class SingleResponseChannel<R> {
 
   void _cancelTimer() {
     if (_timer != null) {
-      _timer.cancel();
+      _timer!.cancel();
       _timer = null;
     }
   }
@@ -363,7 +391,7 @@ class SingleResponseChannel<R> {
       // created in a different error zone, an error from the root zone
       // would become uncaught.
       _zone.run(() {
-        _completer.complete(Future.sync(() => _callback(v)));
+        _completer.complete(Future<R?>.sync(() => _callback!(v)));
       });
     }
   }
@@ -371,7 +399,7 @@ class SingleResponseChannel<R> {
 
 // Helper function that casts an object to a type and completes a
 // corresponding completer, or completes with the error if the cast fails.
-void _castComplete<R>(Completer<R> completer, Object value) {
+void _castComplete<R>(Completer<R> completer, Object? value) {
   try {
     completer.complete(value as R);
   } catch (error, stack) {

--- a/lib/ports.dart
+++ b/lib/ports.dart
@@ -223,11 +223,11 @@ Future<R> singleResponseFutureWithTimeout<R>(
 /// The result of [future] is sent on [resultPort] in a form expected by
 /// either [receiveFutureResult], [completeFutureResult], or
 /// by the port of [singleResultFuture].
-void sendFutureResult(Future<Object?> future, SendPort? resultPort) {
+void sendFutureResult(Future<Object?> future, SendPort resultPort) {
   future.then<Null>((value) {
-    resultPort!.send(list1(value));
+    resultPort.send(list1(value));
   }, onError: (error, stack) {
-    resultPort!.send(list2('$error', '$stack'));
+    resultPort.send(list2('$error', '$stack'));
   });
 }
 

--- a/lib/ports.dart
+++ b/lib/ports.dart
@@ -323,7 +323,7 @@ class SingleResponseChannel<R> {
   final Zone _zone;
   final RawReceivePort _receivePort;
   final Completer<R?> _completer;
-  final Function? _callback;
+  final FutureOr<R> Function(dynamic)? _callback;
   Timer? _timer;
 
   /// Creates a response channel.
@@ -342,7 +342,7 @@ class SingleResponseChannel<R> {
   /// If `onTimeout` is not provided either,
   /// the future is completed with `timeoutValue`, which defaults to `null`.
   SingleResponseChannel(
-      {FutureOr<R> Function(Null value)? callback,
+      {FutureOr<R> Function(dynamic value)? callback,
       Duration? timeout,
       bool throwOnTimeout = false,
       FutureOr<R> Function()? onTimeout,

--- a/lib/ports.dart
+++ b/lib/ports.dart
@@ -366,8 +366,9 @@ class SingleResponseChannel<R> {
   }
 
   void _cancelTimer() {
-    if (_timer != null) {
-      _timer!.cancel();
+    final timer = _timer;
+    if (timer != null) {
+      timer.cancel();
       _timer = null;
     }
   }

--- a/lib/ports.dart
+++ b/lib/ports.dart
@@ -376,7 +376,8 @@ class SingleResponseChannel<R> {
     // Executed as a port event.
     _receivePort.close();
     _cancelTimer();
-    if (_callback == null) {
+    final callback = _callback;
+    if (callback == null) {
       try {
         _completer.complete(v as R);
       } catch (e, s) {
@@ -391,7 +392,7 @@ class SingleResponseChannel<R> {
       // created in a different error zone, an error from the root zone
       // would become uncaught.
       _zone.run(() {
-        _completer.complete(Future<R?>.sync(() => _callback!(v)));
+        _completer.complete(Future<R?>.sync(() => callback(v)));
       });
     }
   }

--- a/lib/registry.dart
+++ b/lib/registry.dart
@@ -194,13 +194,13 @@ class Registry<T> {
     if (id == null) {
       return Future<bool>.value(false);
     }
-    var completer = Completer<bool?>();
-    var port = singleCompletePort(completer, callback: (bool? result) {
+    var completer = Completer<bool>();
+    var port = singleCompletePort(completer, callback: (bool result) {
       _cache.remove(id);
       return result;
     }, timeout: _timeout);
     _commandPort.send(list4(_removeValue, id, removeCapability, port));
-    return completer.future.then((result) => result ?? false);
+    return completer.future;
   }
 
   /// Add tags to objects in the registry.
@@ -255,11 +255,11 @@ class Registry<T> {
       throw RangeError.range(max, 1, null, 'max');
     }
     if (tags != null) tags = tags.toList(growable: false);
-    var completer = Completer<List<T>?>();
-    var port = singleCompletePort(completer, callback: (List? response) {
+    var completer = Completer<List<T>>();
+    var port = singleCompletePort(completer, callback: (List response) {
       // Response is even-length list of (id, element) pairs.
       var cache = _cache;
-      var count = response!.length ~/ 2;
+      var count = response.length ~/ 2;
       var result = List<T?>.filled(count, null);
       for (var i = 0; i < count; i++) {
         var id = response[i * 2] as int;
@@ -270,7 +270,7 @@ class Registry<T> {
       return result;
     }, timeout: _timeout);
     _commandPort.send(list4(_findValue, tags, max, port));
-    return await completer.future ?? List.empty();
+    return await completer.future;
   }
 }
 

--- a/lib/registry.dart
+++ b/lib/registry.dart
@@ -122,7 +122,7 @@ class Registry<T> {
         _timeout = timeout;
 
   _RegistryCache get _cache {
-    _RegistryCache cache = _caches[this];
+    var cache = _caches[this] as _RegistryCache?;
     if (cache != null) return cache;
     cache = _RegistryCache();
     _caches[this] = cache;
@@ -153,7 +153,7 @@ class Registry<T> {
   /// from other elements. Any object can be used as a tag, as long as
   /// it preserves equality when sent through a [SendPort].
   /// This makes [Capability] objects a good choice for tags.
-  Future<Capability> add(T element, {Iterable tags}) {
+  Future<Capability?> add(T element, {Iterable? tags}) {
     var cache = _cache;
     if (cache.contains(element)) {
       return Future<Capability>.sync(() {
@@ -161,7 +161,7 @@ class Registry<T> {
             'Object already in registry: ${Error.safeToString(element)}');
       });
     }
-    var completer = Completer<Capability>();
+    var completer = Completer<Capability?>();
     var port = singleCompletePort(completer,
         callback: (List response) {
           assert(cache.isAdding(element));
@@ -194,13 +194,13 @@ class Registry<T> {
     if (id == null) {
       return Future<bool>.value(false);
     }
-    var completer = Completer<bool>();
-    var port = singleCompletePort(completer, callback: (bool result) {
+    var completer = Completer<bool?>();
+    var port = singleCompletePort(completer, callback: (bool? result) {
       _cache.remove(id);
       return result;
     }, timeout: _timeout);
     _commandPort.send(list4(_removeValue, id, removeCapability, port));
-    return completer.future;
+    return completer.future.then((result) => result ?? false);
   }
 
   /// Add tags to objects in the registry.
@@ -212,9 +212,9 @@ class Registry<T> {
   /// Tags are compared using [Object.==] equality.
   ///
   /// Fails if any of the elements are not in the registry.
-  Future addTags(Iterable<T> elements, Iterable<Object> tags) {
-    List<Object> ids = elements.map(_getId).toList(growable: false);
-    return _addTags(ids, tags);
+  Future addTags(Iterable<T> elements, Iterable<Object?> tags) {
+    List<Object?> ids = elements.map(_getId).toList(growable: false);
+    return _addTags(ids as List<int>, tags);
   }
 
   /// Remove tags from objects in the registry.
@@ -250,27 +250,27 @@ class Registry<T> {
   /// In that case, at most the first `max` results are returned,
   /// in whatever order the registry finds its results.
   /// Otherwise all matching elements are returned.
-  Future<List<T>> lookup({Iterable<Object> tags, int max}) {
+  Future<List<T>> lookup({Iterable<Object?>? tags, int? max}) async {
     if (max != null && max < 1) {
       throw RangeError.range(max, 1, null, 'max');
     }
     if (tags != null) tags = tags.toList(growable: false);
-    var completer = Completer<List<T>>();
-    var port = singleCompletePort(completer, callback: (List response) {
+    var completer = Completer<List<T>?>();
+    var port = singleCompletePort(completer, callback: (List? response) {
       // Response is even-length list of (id, element) pairs.
       var cache = _cache;
-      var count = response.length ~/ 2;
-      var result = List<T>.filled(count, null);
+      var count = response!.length ~/ 2;
+      var result = List<T?>.filled(count, null);
       for (var i = 0; i < count; i++) {
         var id = response[i * 2] as int;
-        var element = response[i * 2 + 1] as T;
-        element = cache.register(id, element);
+        T? element = response[i * 2 + 1] as T;
+        element = cache.register(id, element) as T?;
         result[i] = element;
       }
       return result;
     }, timeout: _timeout);
     _commandPort.send(list4(_findValue, tags, max, port));
-    return completer.future;
+    return await completer.future ?? List.empty();
   }
 }
 
@@ -282,21 +282,21 @@ class _RegistryCache {
   // Temporary marker until an object gets an id.
   static const int _beingAdded = -1;
 
-  final Map<int, Object> id2object = HashMap();
-  final Map<Object, int> object2id = HashMap.identity();
+  final Map<int, Object?> id2object = HashMap();
+  final Map<Object?, int> object2id = HashMap.identity();
 
-  int id(Object object) {
+  int? id(Object? object) {
     var result = object2id[object];
     if (result == _beingAdded) return null;
     return result;
   }
 
-  Object operator [](int id) => id2object[id];
+  Object? operator [](int id) => id2object[id];
 
   // Register a pair of id/object in the cache.
   // if the id is already in the cache, just return the existing
   // object.
-  Object register(int id, Object object) {
+  Object? register(int id, Object? object) {
     object = id2object.putIfAbsent(id, () {
       object2id[object] = id;
       return object;
@@ -335,7 +335,7 @@ class RegistryManager {
   /// Maps id to entry. Each entry contains the id, the element, its tags,
   /// and a capability required to remove it again.
   final _entries = HashMap<int, _RegistryEntry>();
-  final _tag2id = HashMap<Object, Set<int>>();
+  final _tag2id = HashMap<Object?, Set<int>>();
 
   /// Create a new registry managed by the created [RegistryManager].
   ///
@@ -367,7 +367,7 @@ class RegistryManager {
   void _handleCommand(List command) {
     switch (command[0]) {
       case _addValue:
-        _add(command[1], command[2] as List, command[3] as SendPort);
+        _add(command[1], command[2] as List?, command[3] as SendPort);
         return;
       case _removeValue:
         _remove(command[1], command[2] as Capability, command[3] as SendPort);
@@ -382,14 +382,14 @@ class RegistryManager {
         _getTags(command[1], command[2] as SendPort);
         return;
       case _findValue:
-        _find(command[1] as List, command[2] as int, command[3] as SendPort);
+        _find(command[1] as List?, command[2] as int?, command[3] as SendPort);
         return;
       default:
         throw UnsupportedError('Unknown command: ${command[0]}');
     }
   }
 
-  void _add(Object object, List tags, SendPort replyPort) {
+  void _add(object, List? tags, SendPort replyPort) {
     var id = ++_nextId;
     var entry = _RegistryEntry(id, object);
     _entries[id] = entry;
@@ -410,13 +410,12 @@ class RegistryManager {
     }
     _entries.remove(id);
     for (var tag in entry.tags) {
-      _tag2id[tag].remove(id);
+      _tag2id[tag]!.remove(id);
     }
     replyPort.send(true);
   }
 
   void _addTags(List<int> ids, List tags, SendPort replyPort) {
-    assert(tags != null);
     assert(tags.isNotEmpty);
     for (var id in ids) {
       var entry = _entries[id];
@@ -431,7 +430,6 @@ class RegistryManager {
   }
 
   void _removeTags(List<int> ids, List tags, SendPort replyPort) {
-    assert(tags != null);
     assert(tags.isNotEmpty);
     for (var id in ids) {
       var entry = _entries[id];
@@ -439,7 +437,7 @@ class RegistryManager {
       entry.tags.removeAll(tags);
     }
     for (var tag in tags) {
-      Set tagIds = _tag2id[tag];
+      Set? tagIds = _tag2id[tag];
       if (tagIds == null) continue;
       tagIds.removeAll(ids);
     }
@@ -475,7 +473,7 @@ class RegistryManager {
     return matchingIds;
   }
 
-  void _find(List tags, int max, SendPort replyPort) {
+  void _find(List? tags, int? max, SendPort replyPort) {
     assert(max == null || max > 0);
     var result = [];
     if (tags == null || tags.isEmpty) {
@@ -489,12 +487,13 @@ class RegistryManager {
       return;
     }
     var matchingIds = _findTaggedIds(tags);
-    max ??= matchingIds.length; // All results.
+
+    var actualMax = max ?? matchingIds.length; // All results.
     for (var id in matchingIds) {
       result.add(id);
-      result.add(_entries[id].element);
-      max--;
-      if (max == 0) break;
+      result.add(_entries[id]!.element);
+      actualMax -= 1;
+      if (actualMax == 0) break;
     }
     replyPort.send(result);
   }
@@ -510,8 +509,9 @@ class RegistryManager {
 /// Entry in [RegistryManager].
 class _RegistryEntry {
   final int id;
-  final Object element;
+  final Object? element;
   final Set tags = HashSet();
   final Capability removeCapability = Capability();
+
   _RegistryEntry(this.id, this.element);
 }

--- a/lib/registry.dart
+++ b/lib/registry.dart
@@ -153,7 +153,7 @@ class Registry<T> {
   /// from other elements. Any object can be used as a tag, as long as
   /// it preserves equality when sent through a [SendPort].
   /// This makes [Capability] objects a good choice for tags.
-  Future<Capability?> add(T element, {Iterable? tags}) {
+  Future<Capability> add(T element, {Iterable? tags}) {
     var cache = _cache;
     if (cache.contains(element)) {
       return Future<Capability>.sync(() {
@@ -161,7 +161,7 @@ class Registry<T> {
             'Object already in registry: ${Error.safeToString(element)}');
       });
     }
-    var completer = Completer<Capability?>();
+    var completer = Completer<Capability>();
     var port = singleCompletePort(completer,
         callback: (List response) {
           assert(cache.isAdding(element));

--- a/lib/registry.dart
+++ b/lib/registry.dart
@@ -165,8 +165,8 @@ class Registry<T> {
     var port = singleCompletePort(completer,
         callback: (List response) {
           assert(cache.isAdding(element));
-          int id = response[0];
-          Capability removeCapability = response[1];
+          final id = response[0] as int;
+          final removeCapability = response[1] as Capability;
           cache.register(id, element);
           return removeCapability;
         },
@@ -370,16 +370,28 @@ class RegistryManager {
         _add(command[1], command[2] as List?, command[3] as SendPort);
         return;
       case _removeValue:
-        _remove(command[1], command[2] as Capability, command[3] as SendPort);
+        _remove(
+          command[1] as int,
+          command[2] as Capability,
+          command[3] as SendPort,
+        );
         return;
       case _addTagsValue:
-        _addTags(command[1], command[2] as List, command[3] as SendPort);
+        _addTags(
+          command[1] as List<int>,
+          command[2] as List,
+          command[3] as SendPort,
+        );
         return;
       case _removeTagsValue:
-        _removeTags(command[1], command[2] as List, command[3] as SendPort);
+        _removeTags(
+          command[1] as List<int>,
+          command[2] as List,
+          command[3] as SendPort,
+        );
         return;
       case _getTagsValue:
-        _getTags(command[1], command[2] as SendPort);
+        _getTags(command[1] as int, command[2] as SendPort);
         return;
       case _findValue:
         _find(command[1] as List?, command[2] as int?, command[3] as SendPort);

--- a/lib/runner.dart
+++ b/lib/runner.dart
@@ -35,7 +35,7 @@ class Runner {
   /// complete with a [TimeoutException].
   ///
   /// The default implementation runs the function in the current isolate.
-  Future<R?> run<R, P>(FutureOr<R> Function(P argument) function, P argument,
+  Future<R> run<R, P>(FutureOr<R> Function(P argument) function, P argument,
       {Duration? timeout, FutureOr<R> Function()? onTimeout}) {
     var result = Future.sync(() => function(argument));
     if (timeout != null) {
@@ -49,5 +49,5 @@ class Runner {
   /// If the runner has allocated resources, e.g., an isolate, it should
   /// be released. No further calls to [run] should be made after calling
   /// stop.
-  Future<void>? close() => Future.value();
+  Future<void> close() => Future.value();
 }

--- a/lib/runner.dart
+++ b/lib/runner.dart
@@ -35,8 +35,8 @@ class Runner {
   /// complete with a [TimeoutException].
   ///
   /// The default implementation runs the function in the current isolate.
-  Future<R> run<R, P>(FutureOr<R> Function(P argument) function, P argument,
-      {Duration timeout, FutureOr<R> Function() onTimeout}) {
+  Future<R?> run<R, P>(FutureOr<R> Function(P argument) function, P argument,
+      {Duration? timeout, FutureOr<R> Function()? onTimeout}) {
     var result = Future.sync(() => function(argument));
     if (timeout != null) {
       result = result.timeout(timeout, onTimeout: onTimeout);
@@ -49,5 +49,5 @@ class Runner {
   /// If the runner has allocated resources, e.g., an isolate, it should
   /// be released. No further calls to [run] should be made after calling
   /// stop.
-  Future<void> close() => Future.value();
+  Future<void>? close() => Future.value();
 }

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -40,7 +40,7 @@ class MultiError extends Error {
   ///
   /// The order of values is not preserved (if that is needed, use
   /// [wait]).
-  static Future<List<Object?>> waitUnordered<T>(Iterable<Future<T>?> futures,
+  static Future<List<Object?>> waitUnordered<T>(Iterable<Future<T>> futures,
       {void Function(T successResult)? cleanUp}) {
     late Completer<List<Object?>> completer;
     var count = 0;
@@ -82,7 +82,7 @@ class MultiError extends Error {
     };
     for (var future in futures) {
       count++;
-      future!.then<Null>(handleValue, onError: handleError);
+      future.then<Null>(handleValue, onError: handleError);
     }
     if (count == 0) return Future.value(List.filled(0, null));
     results = List.filled(count, null);

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -22,7 +22,7 @@ class MultiError extends Error {
   static const int _minLinesPerError = 1;
 
   /// The actual errors.
-  final List? errors;
+  final List errors;
 
   /// Create a `MultiError` based on a list of errors.
   ///
@@ -49,14 +49,14 @@ class MultiError extends Error {
     // Initialized to `new List(count)` when count is known.
     // Filled up with values on the left, errors on the right.
     // Order is not preserved.
-    List<Object?>? results;
+    late List<Object?> results;
     void checkDone() {
       if (errors + values < count) return;
       if (errors == 0) {
         completer.complete(results);
         return;
       }
-      var errorList = results!.sublist(results.length - errors);
+      var errorList = results.sublist(results.length - errors);
       completer.completeError(MultiError(errorList));
     }
 
@@ -64,7 +64,7 @@ class MultiError extends Error {
       // If this fails because [results] is null, there is a future
       // which breaks the Future API by completing immediately when
       // calling Future.then, probably by misusing a synchronous completer.
-      results![values++] = v;
+      results[values++] = v;
       if (errors > 0 && cleanUp != null) {
         Future.sync(() => cleanUp(v));
       }
@@ -73,11 +73,11 @@ class MultiError extends Error {
     var handleError = (e, s) {
       if (errors == 0 && cleanUp != null) {
         for (var i = 0; i < values; i++) {
-          var value = results![i];
+          var value = results[i];
           if (value != null) Future.sync(() => cleanUp(value as T));
         }
       }
-      results![results.length - ++errors] = e;
+      results[results.length - ++errors] = e;
       checkDone();
     };
     for (var future in futures) {
@@ -108,7 +108,7 @@ class MultiError extends Error {
     // Initialized to `new List(count)` when count is known.
     // Filled with values until the first error, then cleared
     // and filled with errors.
-    List<Object?>? results;
+    late List<Object?> results;
     void checkDone() {
       completed++;
       if (completed < count) return;
@@ -124,7 +124,7 @@ class MultiError extends Error {
       count++;
       future.then<Null>((v) {
         if (!hasError) {
-          results![i] = v;
+          results[i] = v;
         } else if (cleanUp != null) {
           Future.sync(() => cleanUp(v));
         }
@@ -132,15 +132,15 @@ class MultiError extends Error {
       }, onError: (e, s) {
         if (!hasError) {
           if (cleanUp != null) {
-            for (var i = 0; i < results!.length; i++) {
-              var result = results![i];
+            for (var i = 0; i < results.length; i++) {
+              var result = results[i];
               if (result != null) Future.sync(() => cleanUp(result as T));
             }
           }
           results = List<Object?>.filled(count, null);
           hasError = true;
         }
-        results![i] = e;
+        results[i] = e;
         checkDone();
       });
     }
@@ -154,13 +154,13 @@ class MultiError extends Error {
   String toString() {
     var buffer = StringBuffer();
     buffer.write('Multiple Errors:\n');
-    var linesPerError = _maxLines ~/ errors!.length;
+    var linesPerError = _maxLines ~/ errors.length;
     if (linesPerError < _minLinesPerError) {
       linesPerError = _minLinesPerError;
     }
 
-    for (var index = 0; index < errors!.length; index++) {
-      var error = errors![index];
+    for (var index = 0; index < errors.length; index++) {
+      var error = errors[index];
       if (error == null) continue;
       var errorString = error.toString();
       var end = 0;

--- a/lib/src/raw_receive_port_multiplexer.dart
+++ b/lib/src/raw_receive_port_multiplexer.dart
@@ -31,12 +31,12 @@ import 'util.dart';
 class _MultiplexRawReceivePort implements RawReceivePort {
   final RawReceivePortMultiplexer _multiplexer;
   final int _id;
-  Function _handler;
+  Function? _handler;
 
   _MultiplexRawReceivePort(this._multiplexer, this._id, this._handler);
 
   @override
-  set handler(Function handler) {
+  set handler(Function? handler) {
     _handler = handler;
   }
 
@@ -49,7 +49,7 @@ class _MultiplexRawReceivePort implements RawReceivePort {
   SendPort get sendPort => _multiplexer._createSendPort(_id);
 
   void _invokeHandler(message) {
-    _handler(message);
+    _handler!(message);
   }
 }
 
@@ -75,7 +75,7 @@ class RawReceivePortMultiplexer {
     _port.handler = _multiplexResponse;
   }
 
-  RawReceivePort createRawReceivePort([void Function(dynamic) handler]) {
+  RawReceivePort createRawReceivePort([void Function(dynamic)? handler]) {
     var id = _nextId++;
     var result = _MultiplexRawReceivePort(this, id, handler);
     _map[id] = result;
@@ -87,9 +87,9 @@ class RawReceivePortMultiplexer {
   }
 
   void _multiplexResponse(list) {
-    int id = list[0];
+    int? id = list[0];
     var message = list[1];
-    var receivePort = _map[id];
+    var receivePort = _map[id!];
     // If the receive port is closed, messages are dropped, just as for
     // the normal ReceivePort.
     if (receivePort == null) return; // Port closed.

--- a/lib/src/raw_receive_port_multiplexer.dart
+++ b/lib/src/raw_receive_port_multiplexer.dart
@@ -87,9 +87,9 @@ class RawReceivePortMultiplexer {
   }
 
   void _multiplexResponse(list) {
-    int? id = list[0];
+    final id = list[0] as int;
     var message = list[1];
-    var receivePort = _map[id!];
+    var receivePort = _map[id];
     // If the receive port is closed, messages are dropped, just as for
     // the normal ReceivePort.
     if (receivePort == null) return; // Port closed.

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -10,21 +10,21 @@
 void ignore(_) {}
 
 /// Create a single-element fixed-length list.
-List<Object> list1(Object v1) => List.filled(1, v1);
+List<Object?> list1(Object? v1) => List.filled(1, v1);
 
 /// Create a two-element fixed-length list.
-List<Object> list2(Object v1, Object v2) => List.filled(2, null)
+List<Object?> list2(Object? v1, Object? v2) => List.filled(2, null)
   ..[0] = v1
   ..[1] = v2;
 
 /// Create a three-element fixed-length list.
-List<Object> list3(Object v1, Object v2, Object v3) => List.filled(3, null)
+List<Object?> list3(Object? v1, Object? v2, Object? v3) => List.filled(3, null)
   ..[0] = v1
   ..[1] = v2
   ..[2] = v3;
 
 /// Create a four-element fixed-length list.
-List<Object> list4(Object v1, Object v2, Object v3, Object v4) =>
+List<Object?> list4(Object? v1, Object? v2, Object? v3, Object? v4) =>
     List.filled(4, null)
       ..[0] = v1
       ..[1] = v2
@@ -32,7 +32,7 @@ List<Object> list4(Object v1, Object v2, Object v3, Object v4) =>
       ..[3] = v4;
 
 /// Create a five-element fixed-length list.
-List<Object> list5(Object v1, Object v2, Object v3, Object v4, Object v5) =>
+List<Object?> list5(Object? v1, Object? v2, Object? v3, Object? v4, Object? v5) =>
     List.filled(5, null)
       ..[0] = v1
       ..[1] = v2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,10 @@ description: >-
 homepage: https://github.com/dart-lang/isolate
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
+
+dependencies:
+  collection: ^1.15.0
 
 dev_dependencies:
   pedantic: ^1.0.0

--- a/test/isolaterunner_test.dart
+++ b/test/isolaterunner_test.dart
@@ -38,8 +38,8 @@ Future testSeparateIsolates() {
   // Check that each isolate has its own _global variable.
   return Future.wait(Iterable.generate(2, (_) => IsolateRunner.spawn()))
       .then((runners) {
-    Future runAll(Function(IsolateRunner runner, int index) action) {
-      var indices = Iterable.generate(runners.length);
+    Future runAll(Future Function(IsolateRunner runner, int index) action) {
+      final indices = Iterable<int>.generate(runners.length);
       return Future.wait(indices.map((i) => action(runners[i], i)));
     }
 

--- a/test/ports_test.dart
+++ b/test/ports_test.dart
@@ -263,6 +263,28 @@ void testSingleResponseFuture() {
     });
   });
 
+  test('FutureValueWithoutTimeout', () {
+    return singleResponseFutureWithoutTimeout<int>((SendPort p) {
+      p.send(42);
+    }).then<Null>((v) {
+      expect(v, 42);
+    });
+  });
+
+  test('FutureValueWithoutTimeout valid null', () {
+    return singleResponseFutureWithoutTimeout<int?>((SendPort p) {
+      p.send(null);
+    }).then<Null>((v) {
+      expect(v, null);
+    });
+  });
+
+  test('FutureValueWithoutTimeout invalid null', () {
+    return expectLater(singleResponseFutureWithoutTimeout<int>((SendPort p) {
+      p.send(null);
+    }), throwsA(isA<TypeError>()));
+  });
+
   test('FutureValueFirst', () {
     return singleResponseFuture((SendPort p) {
       p.send(42);
@@ -300,7 +322,16 @@ void testSingleResponseFuture() {
     });
   });
 
-  test('FutureTimeoutValue with non-null result', () {
+  test('FutureTimeoutValue with valid null timeoutValue', () {
+    return singleResponseFutureWithTimeout((SendPort p) {
+      // no-op.
+    }, timeout: _ms * 100, timeoutValue: null)
+        .then<Null>((int? v) {
+      expect(v, null);
+    });
+  });
+
+  test('FutureTimeoutValue with non-null timeoutValue', () {
     return singleResponseFutureWithTimeout((SendPort p) {
       // no-op.
     }, timeout: _ms * 100, timeoutValue: 42)

--- a/test/ports_test.dart
+++ b/test/ports_test.dart
@@ -89,7 +89,7 @@ void testSingleCompletePort() {
 
   test('ValueCallback', () {
     final completer = Completer.sync();
-    final p = singleCompletePort(completer, callback: (dynamic v) {
+    final p = singleCompletePort(completer, callback: (v) {
       expect(42, v);
       return 87;
     });
@@ -101,7 +101,7 @@ void testSingleCompletePort() {
 
   test('ValueCallbackFuture', () {
     final completer = Completer.sync();
-    final p = singleCompletePort(completer, callback: (dynamic v) {
+    final p = singleCompletePort(completer, callback: (v) {
       expect(42, v);
       return Future.delayed(_ms * 500, () => 88);
     });
@@ -113,8 +113,7 @@ void testSingleCompletePort() {
 
   test('ValueCallbackThrows', () {
     final completer = Completer.sync();
-    final p =
-        singleCompletePort(completer, callback: (dynamic v) {
+    final p = singleCompletePort(completer, callback: (v) {
       expect(42, v);
       throw 89;
     });
@@ -128,7 +127,7 @@ void testSingleCompletePort() {
 
   test('ValueCallbackThrowsFuture', () {
     final completer = Completer.sync();
-    final p = singleCompletePort(completer, callback: (dynamic v) {
+    final p = singleCompletePort(completer, callback: (v) {
       expect(42, v);
       return Future.error(90);
     });

--- a/test/ports_test.dart
+++ b/test/ports_test.dart
@@ -30,19 +30,29 @@ void testSingleCallbackPort() {
     });
   });
 
+  test('ValueWithoutTimeout non-nullable', () {
+    final completer = Completer<int>.sync();
+    final p = singleCallbackPortWithoutTimeout(completer.complete);
+    p.send(42);
+    return completer.future.then<Null>((int v) {
+      expect(v, 42);
+    });
+  });
+
+  test('ValueWithoutTimeout nullable', () {
+    final completer = Completer<int?>.sync();
+    final p = singleCallbackPortWithoutTimeout(completer.complete);
+    p.send(null);
+    return completer.future.then<Null>((int? v) {
+      expect(v, null);
+    });
+  });
+
   test('FirstValue', () {
     final completer = Completer.sync();
     final p = singleCallbackPort(completer.complete);
     p.send(42);
     p.send(37);
-    return completer.future.then<Null>((v) {
-      expect(v, 42);
-    });
-  });
-  test('Value', () {
-    final completer = Completer.sync();
-    final p = singleCallbackPort(completer.complete);
-    p.send(42);
     return completer.future.then<Null>((v) {
       expect(v, 42);
     });
@@ -73,6 +83,28 @@ void testSingleCallbackPort() {
     Timer(_ms * 500, () => p.send(42));
     return completer.future.then<Null>((v) {
       expect(v, 37);
+    });
+  });
+
+  /// invalid null is a compile time error
+  test('TimeoutFirst with valid null', () {
+    final completer = Completer.sync();
+    final p = singleCallbackPort(completer.complete,
+        timeout: _ms * 100, timeoutValue: null);
+    Timer(_ms * 500, () => p.send(42));
+    return completer.future.then<Null>((v) {
+      expect(v, null);
+    });
+  });
+
+  /// invalid null is a compile time error
+  test('TimeoutFirstWithTimeout with valid null', () {
+    final completer = Completer.sync();
+    final p = singleCallbackPortWithTimeout(completer.complete,
+        timeout: _ms * 100, timeoutValue: null);
+    Timer(_ms * 500, () => p.send(42));
+    return completer.future.then<Null>((v) {
+      expect(v, null);
     });
   });
 }

--- a/test/ports_test.dart
+++ b/test/ports_test.dart
@@ -252,6 +252,28 @@ void testSingleCompletePort() {
       expect(v, 37);
     });
   });
+
+  test('TimeoutFirst with valid null', () {
+    final completer = Completer<int?>.sync();
+    final p = singleCompletePort(completer,
+        timeout: _ms * 100, onTimeout: () => null);
+    Timer(_ms * 500, () => p.send(42));
+    return expectLater(completer.future, completion(null));
+  });
+
+  test('TimeoutFirst with invalid null', () {
+    final completer = Completer<int>.sync();
+
+    /// example of incomplete generic parameters promotion.
+    /// same code with [singleCompletePort<int, dynamic>] is a compile time error
+    final p = singleCompletePort(
+      completer,
+      timeout: _ms * 100,
+      onTimeout: () => null,
+    );
+    Timer(_ms * 500, () => p.send(42));
+    return expectLater(completer.future, throwsA(isA<TypeError>()));
+  });
 }
 
 void testSingleResponseFuture() {

--- a/test/ports_test.dart
+++ b/test/ports_test.dart
@@ -22,56 +22,56 @@ void main() {
 
 void testSingleCallbackPort() {
   test('Value', () {
-    var completer = Completer.sync();
-    var p = singleCallbackPort(completer.complete);
+    final completer = Completer.sync();
+    final p = singleCallbackPort(completer.complete);
     p.send(42);
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       expect(v, 42);
     });
   });
 
   test('FirstValue', () {
-    var completer = Completer.sync();
-    var p = singleCallbackPort(completer.complete);
+    final completer = Completer.sync();
+    final p = singleCallbackPort(completer.complete);
     p.send(42);
     p.send(37);
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       expect(v, 42);
     });
   });
   test('Value', () {
-    var completer = Completer.sync();
-    var p = singleCallbackPort(completer.complete);
+    final completer = Completer.sync();
+    final p = singleCallbackPort(completer.complete);
     p.send(42);
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       expect(v, 42);
     });
   });
 
   test('ValueBeforeTimeout', () {
-    var completer = Completer.sync();
-    var p = singleCallbackPort(completer.complete, timeout: _ms * 500);
+    final completer = Completer.sync();
+    final p = singleCallbackPort(completer.complete, timeout: _ms * 500);
     p.send(42);
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       expect(v, 42);
     });
   });
 
   test('Timeout', () {
-    var completer = Completer.sync();
+    final completer = Completer.sync();
     singleCallbackPort(completer.complete,
         timeout: _ms * 100, timeoutValue: 37);
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       expect(v, 37);
     });
   });
 
   test('TimeoutFirst', () {
-    var completer = Completer.sync();
-    var p = singleCallbackPort(completer.complete,
+    final completer = Completer.sync();
+    final p = singleCallbackPort(completer.complete,
         timeout: _ms * 100, timeoutValue: 37);
     Timer(_ms * 500, () => p.send(42));
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       expect(v, 37);
     });
   });
@@ -79,46 +79,47 @@ void testSingleCallbackPort() {
 
 void testSingleCompletePort() {
   test('Value', () {
-    var completer = Completer.sync();
-    var p = singleCompletePort(completer);
+    final completer = Completer.sync();
+    final p = singleCompletePort(completer);
     p.send(42);
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       expect(v, 42);
     });
   });
 
   test('ValueCallback', () {
-    var completer = Completer.sync();
-    var p = singleCompletePort(completer, callback: (v) {
+    final completer = Completer.sync();
+    final p = singleCompletePort(completer, callback: (dynamic v) {
       expect(42, v);
       return 87;
     });
     p.send(42);
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       expect(v, 87);
     });
   });
 
   test('ValueCallbackFuture', () {
-    var completer = Completer.sync();
-    var p = singleCompletePort(completer, callback: (v) {
+    final completer = Completer.sync();
+    final p = singleCompletePort(completer, callback: (dynamic v) {
       expect(42, v);
       return Future.delayed(_ms * 500, () => 88);
     });
     p.send(42);
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       expect(v, 88);
     });
   });
 
   test('ValueCallbackThrows', () {
-    var completer = Completer.sync();
-    var p = singleCompletePort(completer, callback: (v) {
+    final completer = Completer.sync();
+    final p =
+        singleCompletePort(completer, callback: (dynamic v) {
       expect(42, v);
       throw 89;
     });
     p.send(42);
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) async {
       fail('unreachable');
     }, onError: (e, s) {
       expect(e, 89);
@@ -126,13 +127,13 @@ void testSingleCompletePort() {
   });
 
   test('ValueCallbackThrowsFuture', () {
-    var completer = Completer.sync();
-    var p = singleCompletePort(completer, callback: (v) {
+    final completer = Completer.sync();
+    final p = singleCompletePort(completer, callback: (dynamic v) {
       expect(42, v);
       return Future.error(90);
     });
     p.send(42);
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       fail('unreachable');
     }, onError: (e, s) {
       expect(e, 90);
@@ -140,41 +141,41 @@ void testSingleCompletePort() {
   });
 
   test('FirstValue', () {
-    var completer = Completer.sync();
-    var p = singleCompletePort(completer);
+    final completer = Completer.sync();
+    final p = singleCompletePort(completer);
     p.send(42);
     p.send(37);
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       expect(v, 42);
     });
   });
 
   test('FirstValueCallback', () {
-    var completer = Completer.sync();
-    var p = singleCompletePort(completer, callback: (v) {
+    final completer = Completer.sync();
+    final p = singleCompletePort(completer, callback: (v) {
       expect(v, 42);
       return 87;
     });
     p.send(42);
     p.send(37);
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       expect(v, 87);
     });
   });
 
   test('ValueBeforeTimeout', () {
-    var completer = Completer.sync();
-    var p = singleCompletePort(completer, timeout: _ms * 500);
+    final completer = Completer.sync();
+    final p = singleCompletePort(completer, timeout: _ms * 500);
     p.send(42);
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       expect(v, 42);
     });
   });
 
   test('Timeout', () {
-    var completer = Completer.sync();
+    final completer = Completer.sync();
     singleCompletePort(completer, timeout: _ms * 100);
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       fail('unreachable');
     }, onError: (e, s) {
       expect(e is TimeoutException, isTrue);
@@ -182,18 +183,18 @@ void testSingleCompletePort() {
   });
 
   test('TimeoutCallback', () {
-    var completer = Completer.sync();
+    final completer = Completer.sync();
     singleCompletePort(completer, timeout: _ms * 100, onTimeout: () => 87);
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       expect(v, 87);
     });
   });
 
   test('TimeoutCallbackThrows', () {
-    var completer = Completer.sync();
+    final completer = Completer.sync();
     singleCompletePort(completer,
         timeout: _ms * 100, onTimeout: () => throw 91);
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       fail('unreachable');
     }, onError: (e, s) {
       expect(e, 91);
@@ -201,19 +202,19 @@ void testSingleCompletePort() {
   });
 
   test('TimeoutCallbackFuture', () {
-    var completer = Completer.sync();
+    final completer = Completer.sync();
     singleCompletePort(completer,
         timeout: _ms * 100, onTimeout: () => Future.value(87));
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       expect(v, 87);
     });
   });
 
   test('TimeoutCallbackThrowsFuture', () {
-    var completer = Completer.sync();
+    final completer = Completer.sync();
     singleCompletePort(completer,
         timeout: _ms * 100, onTimeout: () => Future.error(92));
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       fail('unreachable');
     }, onError: (e, s) {
       expect(e, 92);
@@ -221,21 +222,21 @@ void testSingleCompletePort() {
   });
 
   test('TimeoutCallbackSLow', () {
-    var completer = Completer.sync();
+    final completer = Completer.sync();
     singleCompletePort(completer,
         timeout: _ms * 100,
         onTimeout: () => Future.delayed(_ms * 500, () => 87));
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       expect(v, 87);
     });
   });
 
   test('TimeoutCallbackThrowsSlow', () {
-    var completer = Completer.sync();
+    final completer = Completer.sync();
     singleCompletePort(completer,
         timeout: _ms * 100,
         onTimeout: () => Future.delayed(_ms * 500, () => throw 87));
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       fail('unreachable');
     }, onError: (e, s) {
       expect(e, 87);
@@ -243,11 +244,11 @@ void testSingleCompletePort() {
   });
 
   test('TimeoutFirst', () {
-    var completer = Completer.sync();
-    var p =
+    final completer = Completer.sync();
+    final p =
         singleCompletePort(completer, timeout: _ms * 100, onTimeout: () => 37);
     Timer(_ms * 500, () => p.send(42));
-    return completer.future.then((v) {
+    return completer.future.then<Null>((v) {
       expect(v, 37);
     });
   });
@@ -257,7 +258,7 @@ void testSingleResponseFuture() {
   test('FutureValue', () {
     return singleResponseFuture((SendPort p) {
       p.send(42);
-    }).then((v) {
+    }).then<Null>((v) {
       expect(v, 42);
     });
   });
@@ -266,7 +267,7 @@ void testSingleResponseFuture() {
     return singleResponseFuture((SendPort p) {
       p.send(42);
       p.send(37);
-    }).then((v) {
+    }).then<Null>((v) {
       expect(v, 42);
     });
   });
@@ -274,7 +275,7 @@ void testSingleResponseFuture() {
   test('FutureError', () {
     return singleResponseFuture((SendPort p) {
       throw 93;
-    }).then((v) {
+    }).then<Null>((v) {
       fail('unreachable');
     }, onError: (e, s) {
       expect(e, 93);
@@ -285,7 +286,7 @@ void testSingleResponseFuture() {
     return singleResponseFuture((SendPort p) {
       // no-op.
     }, timeout: _ms * 100)
-        .then((v) {
+        .then<Null>((v) {
       expect(v, null);
     });
   });
@@ -294,7 +295,16 @@ void testSingleResponseFuture() {
     return singleResponseFuture((SendPort p) {
       // no-op.
     }, timeout: _ms * 100, timeoutValue: 42)
-        .then((v) {
+        .then<Null>((int? v) {
+      expect(v, 42);
+    });
+  });
+
+  test('FutureTimeoutValue with non-null result', () {
+    return singleResponseFutureWithTimeout((SendPort p) {
+      // no-op.
+    }, timeout: _ms * 100, timeoutValue: 42)
+        .then<Null>((int v) {
       expect(v, 42);
     });
   });
@@ -304,7 +314,7 @@ void testSingleResultFuture() {
   test('Value', () {
     return singleResultFuture((SendPort p) {
       sendFutureResult(Future.value(42), p);
-    }).then((v) {
+    }).then<Null>((v) {
       expect(v, 42);
     });
   });
@@ -313,7 +323,7 @@ void testSingleResultFuture() {
     return singleResultFuture((SendPort p) {
       sendFutureResult(Future.value(42), p);
       sendFutureResult(Future.value(37), p);
-    }).then((v) {
+    }).then<Null>((v) {
       expect(v, 42);
     });
   });
@@ -321,7 +331,7 @@ void testSingleResultFuture() {
   test('Error', () {
     return singleResultFuture((SendPort p) {
       sendFutureResult(Future.error(94), p);
-    }).then((v) {
+    }).then<Null>((v) {
       fail('unreachable');
     }, onError: (e, s) {
       expect(e is RemoteError, isTrue);
@@ -332,7 +342,7 @@ void testSingleResultFuture() {
     return singleResultFuture((SendPort p) {
       sendFutureResult(Future.error(95), p);
       sendFutureResult(Future.error(96), p);
-    }).then((v) {
+    }).then<Null>((v) {
       fail('unreachable');
     }, onError: (e, s) {
       expect(e is RemoteError, isTrue);
@@ -342,7 +352,7 @@ void testSingleResultFuture() {
   test('Error', () {
     return singleResultFuture((SendPort p) {
       throw 93;
-    }).then((v) {
+    }).then<Null>((v) {
       fail('unreachable');
     }, onError: (e, s) {
       expect(e is RemoteError, isTrue);
@@ -353,7 +363,7 @@ void testSingleResultFuture() {
     return singleResultFuture((SendPort p) {
       // no-op.
     }, timeout: _ms * 100)
-        .then((v) {
+        .then<Null>((v) {
       fail('unreachable');
     }, onError: (e, s) {
       expect(e is TimeoutException, isTrue);
@@ -363,15 +373,15 @@ void testSingleResultFuture() {
   test('TimeoutValue', () {
     return singleResultFuture((SendPort p) {
       // no-op.
-    }, timeout: _ms * 100, onTimeout: () => 42).then((v) {
+    }, timeout: _ms * 100, onTimeout: () => 42).then<Null>((v) {
       expect(v, 42);
     });
   });
 
   test('TimeoutError', () {
     return singleResultFuture((SendPort p) {
-      // no-op.
-    }, timeout: _ms * 100, onTimeout: () => throw 97).then((v) {
+      return null;
+    }, timeout: _ms * 100, onTimeout: () => throw 97).then<Null>((v) {
       expect(v, 42);
     }, onError: (e, s) {
       expect(e, 97);
@@ -381,34 +391,34 @@ void testSingleResultFuture() {
 
 void testSingleResponseChannel() {
   test('Value', () {
-    var channel = SingleResponseChannel();
+    final channel = SingleResponseChannel();
     channel.port.send(42);
-    return channel.result.then((v) {
+    return channel.result.then<Null>((v) {
       expect(v, 42);
     });
   });
 
   test('ValueFirst', () {
-    var channel = SingleResponseChannel();
+    final channel = SingleResponseChannel();
     channel.port.send(42);
     channel.port.send(37);
-    return channel.result.then((v) {
+    return channel.result.then<Null>((v) {
       expect(v, 42);
     });
   });
 
   test('ValueCallback', () {
-    var channel = SingleResponseChannel(callback: (v) => 2 * v);
+    final channel = SingleResponseChannel(callback: ((v) => 2 * (v as num)));
     channel.port.send(42);
-    return channel.result.then((v) {
+    return channel.result.then<Null>((v) {
       expect(v, 84);
     });
   });
 
   test('ErrorCallback', () {
-    var channel = SingleResponseChannel(callback: (v) => throw 42);
+    final channel = SingleResponseChannel(callback: ((v) => throw 42));
     channel.port.send(37);
-    return channel.result.then((v) {
+    return channel.result.then<Null>((v) {
       fail('unreachable');
     }, onError: (v, s) {
       expect(v, 42);
@@ -416,17 +426,18 @@ void testSingleResponseChannel() {
   });
 
   test('AsyncValueCallback', () {
-    var channel = SingleResponseChannel(callback: (v) => Future.value(2 * v));
+    final channel =
+        SingleResponseChannel(callback: ((v) => Future.value(2 * (v as num))));
     channel.port.send(42);
-    return channel.result.then((v) {
+    return channel.result.then<Null>((v) {
       expect(v, 84);
     });
   });
 
   test('AsyncErrorCallback', () {
-    var channel = SingleResponseChannel(callback: (v) => Future.error(42));
+    final channel = SingleResponseChannel(callback: ((v) => Future.error(42)));
     channel.port.send(37);
-    return channel.result.then((v) {
+    return channel.result.then<Null>((v) {
       fail('unreachable');
     }, onError: (v, s) {
       expect(v, 42);
@@ -434,16 +445,16 @@ void testSingleResponseChannel() {
   });
 
   test('Timeout', () {
-    var channel = SingleResponseChannel(timeout: _ms * 100);
-    return channel.result.then((v) {
+    final channel = SingleResponseChannel(timeout: _ms * 100);
+    return channel.result.then<Null>((v) {
       expect(v, null);
     });
   });
 
   test('TimeoutThrow', () {
-    var channel =
+    final channel =
         SingleResponseChannel(timeout: _ms * 100, throwOnTimeout: true);
-    return channel.result.then((v) {
+    return channel.result.then<Null>((v) {
       fail('unreachable');
     }, onError: (v, s) {
       expect(v is TimeoutException, isTrue);
@@ -451,12 +462,12 @@ void testSingleResponseChannel() {
   });
 
   test('TimeoutThrowOnTimeoutAndValue', () {
-    var channel = SingleResponseChannel(
+    final channel = SingleResponseChannel(
         timeout: _ms * 100,
         throwOnTimeout: true,
         onTimeout: () => 42,
         timeoutValue: 42);
-    return channel.result.then((v) {
+    return channel.result.then<Null>((v) {
       fail('unreachable');
     }, onError: (v, s) {
       expect(v is TimeoutException, isTrue);
@@ -464,32 +475,32 @@ void testSingleResponseChannel() {
   });
 
   test('TimeoutOnTimeout', () {
-    var channel =
+    final channel =
         SingleResponseChannel(timeout: _ms * 100, onTimeout: () => 42);
-    return channel.result.then((v) {
+    return channel.result.then<Null>((v) {
       expect(v, 42);
     });
   });
 
   test('TimeoutOnTimeoutAndValue', () {
-    var channel = SingleResponseChannel(
+    final channel = SingleResponseChannel(
         timeout: _ms * 100, onTimeout: () => 42, timeoutValue: 37);
-    return channel.result.then((v) {
+    return channel.result.then<Null>((v) {
       expect(v, 42);
     });
   });
 
   test('TimeoutValue', () {
-    var channel = SingleResponseChannel(timeout: _ms * 100, timeoutValue: 42);
-    return channel.result.then((v) {
+    final channel = SingleResponseChannel(timeout: _ms * 100, timeoutValue: 42);
+    return channel.result.then<Null>((v) {
       expect(v, 42);
     });
   });
 
   test('TimeoutOnTimeoutError', () {
-    var channel =
+    final channel =
         SingleResponseChannel(timeout: _ms * 100, onTimeout: () => throw 42);
-    return channel.result.then((v) {
+    return channel.result.then<Null>((v) {
       fail('unreachable');
     }, onError: (v, s) {
       expect(v, 42);
@@ -497,17 +508,17 @@ void testSingleResponseChannel() {
   });
 
   test('TimeoutOnTimeoutAsync', () {
-    var channel = SingleResponseChannel(
+    final channel = SingleResponseChannel(
         timeout: _ms * 100, onTimeout: () => Future.value(42));
-    return channel.result.then((v) {
+    return channel.result.then<Null>((v) {
       expect(v, 42);
     });
   });
 
   test('TimeoutOnTimeoutAsyncError', () {
-    var channel = SingleResponseChannel(
+    final channel = SingleResponseChannel(
         timeout: _ms * 100, onTimeout: () => Future.error(42));
-    return channel.result.then((v) {
+    return channel.result.then<Null>((v) {
       fail('unreachable');
     }, onError: (v, s) {
       expect(v, 42);

--- a/test/registry_test.dart
+++ b/test/registry_test.dart
@@ -240,7 +240,7 @@ void testRemove() {
       return registry.lookup().then((entries) {
         expect(entries, hasLength(1));
         expect(entries.first, same(object));
-        return registry.remove(object, removeCapability!);
+        return registry.remove(object, removeCapability);
       });
     }).then((removeSuccess) {
       expect(removeSuccess, isTrue);
@@ -369,7 +369,7 @@ void testCrossIsolate() {
           return registry.lookup(tags: ['a']).then((entries) {
             expect(entries, hasLength(1));
             expect(entries.first, same(object));
-            return registry.remove(entries.first, removeCapability!);
+            return registry.remove(entries.first, removeCapability);
           }).then<Null>((removeSuccess) {
             expect(removeSuccess, isTrue);
           });
@@ -401,7 +401,7 @@ void testTimeout() {
     var object = Object();
     return registry.add(object).then((rc) {
       regman.close();
-      return registry.remove(object, rc!).then<Null>((_) {
+      return registry.remove(object, rc).then<Null>((_) {
         fail('unreachable');
       }, onError: (e, s) {
         expect(e is TimeoutException, isTrue);
@@ -464,10 +464,10 @@ void testMultiRegistry() {
         // The object for registry2 is not identical the one for registry1.
         expect(!identical(l1, l2), isTrue);
         // Removing the registry1 object through registry2 doesn't work.
-        return registry2.remove(l1, removeCapability!);
+        return registry2.remove(l1, removeCapability);
       }).then((removeSuccess) {
         expect(removeSuccess, isFalse);
-        return registry2.remove(l2, removeCapability!);
+        return registry2.remove(l2, removeCapability);
       }).then((removeSuccess) {
         expect(removeSuccess, isTrue);
         return registry1.lookup();
@@ -499,7 +499,7 @@ void testObjectsAndTags() {
         }).then((entries) {
           expect(entries, hasLength(1));
           expect(entries.first, equals(object));
-          return registry2.remove(entries.first, removeCapability!);
+          return registry2.remove(entries.first, removeCapability);
         }).then((removeSuccess) {
           expect(removeSuccess, isTrue);
           return registry2.lookup();

--- a/test/registry_test.dart
+++ b/test/registry_test.dart
@@ -9,7 +9,6 @@ import 'dart:isolate';
 
 import 'package:isolate/isolate_runner.dart';
 import 'package:isolate/registry.dart';
-
 import 'package:test/test.dart';
 
 const _ms = Duration(milliseconds: 1);
@@ -44,7 +43,7 @@ void testLookup() {
       return registry.add(element, tags: [tag]);
     }).then((_) {
       return registry.lookup();
-    }).then((all) {
+    }).then<Null>((all) {
       expect(all.length, 10);
       expect(all.map((v) => v.id).toList()..sort(),
           [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
@@ -60,7 +59,7 @@ void testLookup() {
       return registry.add(element, tags: [tag]);
     }).then((_) {
       return registry.lookup(tags: [Oddity.odd]);
-    }).then((all) {
+    }).then<Null>((all) {
       expect(all.length, 5);
       expect(all.map((v) => v.id).toList()..sort(), [1, 3, 5, 7, 9]);
     }).whenComplete(regman.close);
@@ -75,7 +74,7 @@ void testLookup() {
       return registry.add(element, tags: [tag]);
     }).then((_) {
       return registry.lookup(max: 5);
-    }).then((all) {
+    }).then<Null>((all) {
       expect(all.length, 5);
     }).whenComplete(regman.close);
   });
@@ -93,7 +92,7 @@ void testLookup() {
       return registry.add(element, tags: tags);
     }).then((_) {
       return registry.lookup(tags: [2, 3]);
-    }).then((all) {
+    }).then<Null>((all) {
       expect(all.length, 5);
       expect(all.map((v) => v.id).toList()..sort(), [0, 6, 12, 18, 24]);
     }).whenComplete(regman.close);
@@ -112,7 +111,7 @@ void testLookup() {
       return registry.add(element, tags: tags);
     }).then((_) {
       return registry.lookup(tags: [2, 3], max: 3);
-    }).then((all) {
+    }).then<Null>((all) {
       expect(all.length, 3);
       expect(all.every((v) => (v.id % 6) == 0), isTrue);
     }).whenComplete(regman.close);
@@ -126,7 +125,7 @@ void testAddLookup() {
     var object = Object();
     return registry.add(object).then((_) {
       return registry.lookup();
-    }).then((entries) {
+    }).then<Null>((entries) {
       expect(entries, hasLength(1));
       expect(entries.first, same(object));
     }).whenComplete(regman.close);
@@ -141,7 +140,7 @@ void testAddLookup() {
     var objects = [object1, object2, object3];
     return Future.wait(objects.map(registry.add)).then((_) {
       return registry.lookup();
-    }).then((entries) {
+    }).then<Null>((entries) {
       expect(entries, hasLength(3));
       for (var entry in entries) {
         expect(entry, isIn(objects));
@@ -155,7 +154,7 @@ void testAddLookup() {
     var object = Object();
     return registry.add(object).then((_) {
       return registry.add(object);
-    }).then((_) {
+    }).then<Null>((_) {
       fail('Unreachable');
     }, onError: (e, s) {
       expect(e, isStateError);
@@ -175,7 +174,7 @@ void testAddLookup() {
       return registry.add(object2);
     }).then((_) {
       return registry.lookup();
-    }).then((entries) {
+    }).then<Null>((entries) {
       expect(entries, hasLength(2));
       var entry1 = entries.first;
       var entry2 = entries.last;
@@ -196,7 +195,7 @@ void testAddLookup() {
       return registry.add(object);
     }).then((_) {
       return registry.lookup();
-    }).then((entries) {
+    }).then<Null>((entries) {
       expect(entries, hasLength(1));
       expect(entries.first, same(object));
     }).whenComplete(regman.close);
@@ -214,18 +213,18 @@ void testAddLookup() {
       return registry.add(object3, tags: [4, 5, 6, 7]);
     }).then((_) {
       return registry.lookup(tags: [3]);
-    }).then((entries) {
+    }).then<Null>((entries) {
       expect(entries, hasLength(2));
       expect(entries.first == object1 || entries.last == object1, isTrue);
       expect(entries.first == object2 || entries.last == object2, isTrue);
     }).then((_) {
       return registry.lookup(tags: [2]);
-    }).then((entries) {
+    }).then<Null>((entries) {
       expect(entries, hasLength(1));
       expect(entries.first, same(object2));
     }).then((_) {
       return registry.lookup(tags: [3, 6]);
-    }).then((entries) {
+    }).then<Null>((entries) {
       expect(entries, hasLength(1));
       expect(entries.first, same(object2));
     }).whenComplete(regman.close);
@@ -241,12 +240,12 @@ void testRemove() {
       return registry.lookup().then((entries) {
         expect(entries, hasLength(1));
         expect(entries.first, same(object));
-        return registry.remove(object, removeCapability);
+        return registry.remove(object, removeCapability!);
       });
     }).then((removeSuccess) {
       expect(removeSuccess, isTrue);
       return registry.lookup();
-    }).then((entries) {
+    }).then<Null>((entries) {
       expect(entries, isEmpty);
     }).whenComplete(regman.close);
   });
@@ -261,7 +260,7 @@ void testRemove() {
         expect(entries.first, same(object));
         return registry.remove(object, Capability());
       });
-    }).then((removeSuccess) {
+    }).then<Null>((removeSuccess) {
       expect(removeSuccess, isFalse);
     }).whenComplete(regman.close);
   });
@@ -285,7 +284,7 @@ void testAddRemoveTags() {
       return registry.removeTags([object], ['x']);
     }).then((_) {
       return registry.lookup(tags: ['x']);
-    }).then((entries) {
+    }).then<Null>((entries) {
       expect(entries, isEmpty);
     }).whenComplete(regman.close);
   });
@@ -349,6 +348,7 @@ void testAddRemoveTags() {
 }
 
 var _regmen = {};
+
 Registry createRegMan(id) {
   var regman = RegistryManager();
   _regmen[id] = regman;
@@ -369,8 +369,8 @@ void testCrossIsolate() {
           return registry.lookup(tags: ['a']).then((entries) {
             expect(entries, hasLength(1));
             expect(entries.first, same(object));
-            return registry.remove(entries.first, removeCapability);
-          }).then((removeSuccess) {
+            return registry.remove(entries.first, removeCapability!);
+          }).then<Null>((removeSuccess) {
             expect(removeSuccess, isTrue);
           });
         });
@@ -388,7 +388,7 @@ void testTimeout() {
     var regman = RegistryManager(timeout: _ms * 500);
     var registry = regman.registry;
     regman.close();
-    return registry.add(Object()).then((_) {
+    return registry.add(Object()).then<Null>((_) {
       fail('unreachable');
     }, onError: (e, s) {
       expect(e is TimeoutException, isTrue);
@@ -401,7 +401,7 @@ void testTimeout() {
     var object = Object();
     return registry.add(object).then((rc) {
       regman.close();
-      return registry.remove(object, rc).then((_) {
+      return registry.remove(object, rc!).then<Null>((_) {
         fail('unreachable');
       }, onError: (e, s) {
         expect(e is TimeoutException, isTrue);
@@ -415,7 +415,7 @@ void testTimeout() {
     var object = Object();
     return registry.add(object).then((rc) {
       regman.close();
-      return registry.addTags([object], ['x']).then((_) {
+      return registry.addTags([object], ['x']).then<Null>((_) {
         fail('unreachable');
       }, onError: (e, s) {
         expect(e is TimeoutException, isTrue);
@@ -429,7 +429,7 @@ void testTimeout() {
     var object = Object();
     return registry.add(object).then((rc) {
       regman.close();
-      return registry.removeTags([object], ['x']).then((_) {
+      return registry.removeTags([object], ['x']).then<Null>((_) {
         fail('unreachable');
       }, onError: (e, s) {
         expect(e is TimeoutException, isTrue);
@@ -441,7 +441,7 @@ void testTimeout() {
     var regman = RegistryManager(timeout: _ms * 500);
     var registry = regman.registry;
     regman.close();
-    registry.lookup().then((_) {
+    registry.lookup().then<Null>((_) {
       fail('unreachable');
     }, onError: (e, s) {
       expect(e is TimeoutException, isTrue);
@@ -464,14 +464,14 @@ void testMultiRegistry() {
         // The object for registry2 is not identical the one for registry1.
         expect(!identical(l1, l2), isTrue);
         // Removing the registry1 object through registry2 doesn't work.
-        return registry2.remove(l1, removeCapability);
+        return registry2.remove(l1, removeCapability!);
       }).then((removeSuccess) {
         expect(removeSuccess, isFalse);
-        return registry2.remove(l2, removeCapability);
+        return registry2.remove(l2, removeCapability!);
       }).then((removeSuccess) {
         expect(removeSuccess, isTrue);
         return registry1.lookup();
-      }).then((entries) {
+      }).then<Null>((entries) {
         expect(entries, isEmpty);
       });
     }).whenComplete(regman.close);
@@ -499,11 +499,11 @@ void testObjectsAndTags() {
         }).then((entries) {
           expect(entries, hasLength(1));
           expect(entries.first, equals(object));
-          return registry2.remove(entries.first, removeCapability);
+          return registry2.remove(entries.first, removeCapability!);
         }).then((removeSuccess) {
           expect(removeSuccess, isTrue);
           return registry2.lookup();
-        }).then((entries) {
+        }).then<Null>((entries) {
           expect(entries, isEmpty);
         });
       }).whenComplete(regman.close);
@@ -526,11 +526,14 @@ void testObjectsAndTags() {
 
 class Element {
   final int id;
+
   Element(this.id);
+
   @override
   int get hashCode => id;
+
   @override
-  bool operator ==(Object other) => other is Element && id == other.id;
+  bool operator ==(Object? other) => other is Element && id == other.id;
 }
 
 void topLevelFunction() {}


### PR DESCRIPTION
Closes #43

- enable nullsafety
- add generic parameter in `then` clauses without return: `then<Null>`
   fixes `Null is not a subtype of Future<Never>`
- replace custom priority queue with `PriorityQueue` from [package:collection](https://github.com/dart-lang/collection) to get rid of nullable `_LoadBalancerEntry` everywhere
